### PR TITLE
Add dev PostgreSQL docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+db:
+  image: postgres
+  ports:
+    - "5432:5432"


### PR DESCRIPTION
In order to use PostgreSQL while developing
For developers
We will add docker container that runs PostgreSQL
Whereas currently we need PostgreSQL installed on our local machine
 
Closes #28