### PR TITLE
Doctrine should be set up using params not url

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -12,5 +12,12 @@ APP_SECRET=f89cdd4e751e8144aeb61d81fb78fc65
 # Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
 # Set "serverVersion" to your server version to avoid edge-case exceptions and extra database calls
-DATABASE_URL="mysql://root@127.0.0.1:3306/symfony?charset=utf8mb4&serverVersion=5.7"
+#DATABASE_URL="pgsql://root:n0p455@pgsql_dev:5432/?dbname=raffler"
+DATABASE_DRIVER=pdo_pgsql
+DATABASE_SERVER_VERSION=10.0
+DATABASE_HOST=raffler_dev
+DATABASE_PORT=5432
+DATABASE_NAME=raffler_dev
+DATABASE_USER=root
+DATABASE_PASSWORD=n0p455
 ###< doctrine/doctrine-bundle ###

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,6 +1,13 @@
 doctrine:
     dbal:
-        url: '%env(DATABASE_URL)%'
+        driver:   '%env(DATABASE_DRIVER)%'
+        host:     '%env(DATABASE_HOST)%'
+        port:     '%env(DATABASE_PORT)%'
+        dbname:   '%env(DATABASE_NAME)%'
+        user:     '%env(DATABASE_USER)%'
+        password: '%env(DATABASE_PASSWORD)%'
+        charset:  UTF8
+        server_version: '%env(DATABASE_SERVER_VERSION)%'
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/config/packages/test/doctrine.yaml
+++ b/config/packages/test/doctrine.yaml
@@ -1,0 +1,3 @@
+doctrine:
+    dbal:
+        dbname:   'raffler_test'


### PR DESCRIPTION
There are issues with droping PostgreSQL database when using URL, lets
use the params like we did in Symfony 2/3 apps

Closes #34