### PR TITLE
JoindInEvent url's should be prefixed with /joindin/events

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -2,13 +2,13 @@ homepage:
     path: /
     defaults: { _controller: 'App\Controller\HomepageController::index' }
 
-fetch:
-    path: /joindin/fetch
+joindin_events_fetch:
+    path: /joindin/events/fetch
     defaults: { _controller: 'App\Controller\JoindInEventController::fetch' }
 
 
-list:
-    path: /joindin/list
+joindin_events_list:
+    path: /joindin/events/
     defaults: { _controller: 'App\Controller\JoindInEventController::eventList' }
 
 

--- a/features/bootstrap/ApiContext.php
+++ b/features/bootstrap/ApiContext.php
@@ -61,7 +61,7 @@ class ApiContext implements Context
      */
     public function iFetchMeetupDataFromJoindIn()
     {
-        $this->getGuzzle()->get('http://test.raffler.loc:8000/joindin/fetch');
+        $this->getGuzzle()->get('http://test.raffler.loc:8000/joindin/events/fetch');
     }
 
     /**
@@ -77,7 +77,7 @@ class ApiContext implements Context
      */
     public function thereShouldBeZgphpMeetupsInSystem(int $count)
     {
-        $response = $this->getGuzzle()->get('http://test.raffler.loc:8000/joindin/list');
+        $response = $this->getGuzzle()->get('http://test.raffler.loc:8000/joindin/events/');
 
         $data = json_decode($response->getBody()->getContents(), true);
 


### PR DESCRIPTION
In order to better organize our URL's
For maintainers
We should prefix all of the API endpoints related to JoindInEvent with consistent prefix


Closes #60