### PR TITLE
#51 - Sort event list newest->oldest

### DIFF
--- a/src/Controller/JoindInEventController.php
+++ b/src/Controller/JoindInEventController.php
@@ -42,7 +42,7 @@ class JoindInEventController
 
     public function eventList()
     {
-        $events = $this->eventRepository->findAll();
+        $events = $this->eventRepository->findAllSortedFromNewestToOldest();
 
         return new JsonResponse($events);
     }

--- a/src/Repository/JoindInEventRepository.php
+++ b/src/Repository/JoindInEventRepository.php
@@ -6,4 +6,11 @@ use Doctrine\ORM\EntityRepository;
 
 class JoindInEventRepository extends EntityRepository
 {
+    /**
+     * @return \App\Entity\JoindInEvent[]
+     */
+    public function findAllSortedFromNewestToOldest(): array
+    {
+        return $this->findBy([], ['startDate' => 'DESC']);
+    }
 }


### PR DESCRIPTION
Event list is now sorted from newest to oldest.
I've overridden the findAll() method by adding 'startDate' as search
param and sorting the result set.
 
Closes #51

