### PR TITLE
#53 - Remove JoindinClient param from JoindinEventController

### DIFF
--- a/src/Controller/JoindInEventController.php
+++ b/src/Controller/JoindInEventController.php
@@ -3,7 +3,6 @@
 namespace App\Controller;
 
 use App\Repository\JoindInEventRepository;
-use App\Service\JoindInClient;
 use App\Service\JoindInEventRetrieval;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -13,10 +12,6 @@ class JoindInEventController
      * @var JoindInEventRepository
      */
     private $eventRepository;
-    /**
-     * @var JoindInClient
-     */
-    private $joindInClient;
 
     /**
      * @var JoindInEventRetrieval
@@ -25,11 +20,9 @@ class JoindInEventController
 
     public function __construct(
         JoindInEventRetrieval $joindInEventRetrieval,
-        JoindInEventRepository $eventRepository,
-        JoindInClient $joindInClient
+        JoindInEventRepository $eventRepository
     ) {
         $this->eventRepository       = $eventRepository;
-        $this->joindInClient         = $joindInClient;
         $this->joindInEventRetrieval = $joindInEventRetrieval;
     }
 


### PR DESCRIPTION
Since the JoindinClient isn't used in JoindinEventController,
we removed it.

Closes #53 

