### PR TITLE
Add data fixtures for Talks, Users, and Comments

### DIFF
--- a/src/DataFixtures/ORM/JoindInCommentsFixtures.php
+++ b/src/DataFixtures/ORM/JoindInCommentsFixtures.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures\ORM;
+
+use App\Entity\JoindInComment;
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class JoindInCommentsFixtures extends AbstractFixture implements OrderedFixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {
+        $fullStacking101Talk = $this->getReference('october-talk-22817');
+
+        $fullStackingComments = [
+            'comment1' => new JoindInComment(
+                83645,
+                'A nice overview of all the pros and cons of knowing a lot of stuff and how to learn
+                 a new technology and then use it in your daily routines',
+                5,
+                $this->getReference('user2'),
+                $fullStacking101Talk
+            ),
+        ];
+
+        $httpCachingTalk = $this->getReference('october-talk-22818');
+
+        $httpCachingComments = [
+            'comment1' => new JoindInComment(
+                83555,
+                'Great talk, some very useful Symfony HTTP cache tips and how-to were mentioned.',
+                5,
+                $this->getReference('user1'),
+                $httpCachingTalk
+            ),
+            'comment2' => new JoindInComment(
+                83646,
+                'Great insight on how to use and implement http caching on a huge project.
+                 Really liked the small details and real life examples that happen in the real world :)',
+                5,
+                $this->getReference('user2'),
+                $httpCachingTalk
+            ),
+        ];
+
+        foreach ($fullStackingComments as $commentRef => $fullStackingComment) {
+            $manager->persist($fullStackingComment);
+            $this->addReference('fullStacking-'.$commentRef, $fullStackingComment);
+        }
+
+        foreach ($httpCachingComments as $commentRef => $httpCachingComment) {
+            $manager->persist($httpCachingComment);
+            $this->addReference('httpCaching-'.$commentRef, $httpCachingComment);
+        }
+
+        $manager->flush();
+    }
+
+    public function getOrder()
+    {
+        return 40;
+    }
+}

--- a/src/DataFixtures/ORM/JoindInTalksFixtures.php
+++ b/src/DataFixtures/ORM/JoindInTalksFixtures.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures\ORM;
+
+use App\Entity\JoindInTalk;
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class JoindInTalksFixtures extends AbstractFixture implements OrderedFixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {
+        $octoberMeetup = $this->getReference('event-october');
+
+        $octoberTalks = [
+            22817 => new JoindInTalk(22817, 'Fullstacking - 101', $octoberMeetup),
+            22818 => new JoindInTalk(22818, 'HTTP caching - symfony, varnish, invalidation, naming',
+                $octoberMeetup),
+        ];
+
+        foreach ($octoberTalks as $talkID => $talk) {
+            $manager->persist($talk);
+            $this->addReference('october-talk-'.$talkID, $talk);
+        }
+
+        $manager->flush();
+    }
+
+    public function getOrder()
+    {
+        return 20;
+    }
+}

--- a/src/DataFixtures/ORM/JoindInUsersFixtures.php
+++ b/src/DataFixtures/ORM/JoindInUsersFixtures.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures\ORM;
+
+use App\Entity\JoindInUser;
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class JoindInUsersFixtures extends AbstractFixture implements OrderedFixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {
+        $users = [
+            'user1' => new JoindInUser(45128, 'username1', 'User Named One'),
+            'user2' => new JoindInUser(26764, 'username2', 'User Named Two'),
+        ];
+
+        foreach ($users as $userRef => $user) {
+            $manager->persist($user);
+            $this->addReference($userRef, $user);
+        }
+
+        $manager->flush();
+    }
+
+    public function getOrder()
+    {
+        return 30;
+    }
+}


### PR DESCRIPTION
In order to have some data to work with while developing the system
For developers
We should add data fixtures to seed the database
Otherwise developers will waste time inserting dummy data by themselves
Closes #67 

