### PR TITLE
All API endpoints should be under api/ route

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -3,32 +3,32 @@ homepage:
     defaults: { _controller: 'App\Controller\HomepageController::index' }
 
 joindin_events_fetch:
-    path: /joindin/events/fetch
+    path: /api/joindin/events/fetch
     defaults: { _controller: 'App\Controller\JoindInEventController::fetch' }
 
 
 joindin_events_list:
-    path: /joindin/events/
+    path: /api/joindin/events/
     defaults: { _controller: 'App\Controller\JoindInEventController::eventList' }
 
 
 talks_fetch:
-    path: /joindin/talks/fetch
+    path: /api/joindin/talks/fetch
     defaults: { _controller: 'App\Controller\JoindInTalkController::fetch' }
 
 
 talks_list:
-    path: /joindin/talks/
+    path: /api/joindin/talks/
     defaults: { _controller: 'App\Controller\JoindInTalkController::talkList' }
 
 
 comments_fetch:
-    path: /joindin/comments/fetch
+    path: /api/joindin/comments/fetch
     defaults: { _controller: 'App\Controller\JoindInCommentController::fetch' }
 
 
 comments_list:
-    path: /joindin/comments/
+    path: /api/joindin/comments/
     defaults: { _controller: 'App\Controller\JoindInCommentController::commentList' }
 
 

--- a/features/bootstrap/ApiContext.php
+++ b/features/bootstrap/ApiContext.php
@@ -40,7 +40,7 @@ class ApiContext extends BaseContext
      */
     public function iFetchMeetupDataFromJoindIn()
     {
-        $this->apiGetJson('/joindin/events/fetch');
+        $this->apiGetJson('/api/joindin/events/fetch');
     }
 
     /**
@@ -48,7 +48,7 @@ class ApiContext extends BaseContext
      */
     public function iFetchMeetupTalksFromJoindIn()
     {
-        $this->apiGetJson('/joindin/talks/fetch');
+        $this->apiGetJson('/api/joindin/talks/fetch');
     }
 
     /**
@@ -56,7 +56,7 @@ class ApiContext extends BaseContext
      */
     public function iFetchMeetupTalkCommentsFromJoindIn()
     {
-        $this->apiGetJson('/joindin/comments/fetch');
+        $this->apiGetJson('/api/joindin/comments/fetch');
     }
 
     /**
@@ -106,7 +106,7 @@ class ApiContext extends BaseContext
      */
     public function thereShouldBeZgphpMeetupsInSystem(int $count)
     {
-        Assert::count($this->apiGetJson('/joindin/events/'), $count);
+        Assert::count($this->apiGetJson('/api/joindin/events/'), $count);
     }
 
     /**
@@ -114,7 +114,7 @@ class ApiContext extends BaseContext
      */
     public function thereShouldBeTalksInSystem(int $count)
     {
-        Assert::count($this->apiGetJson('/joindin/talks/'), $count);
+        Assert::count($this->apiGetJson('/api/joindin/talks/'), $count);
     }
 
     /**
@@ -122,7 +122,7 @@ class ApiContext extends BaseContext
      */
     public function thereShouldBeCommentInSystem(int $count)
     {
-        $data = $this->apiGetJson('/joindin/comments/');
+        $data = $this->apiGetJson('/api/joindin/comments/');
 
         Assert::count($data, $count);
     }


### PR DESCRIPTION
We want to keep all the API related endpoints under one route, adding "api/" to joind in URLs