### PR TITLE
Replace start & end date with a date

### DIFF
--- a/features/bootstrap/FixturesContext.php
+++ b/features/bootstrap/FixturesContext.php
@@ -53,12 +53,8 @@ class FixturesContext extends BaseContext
         $this->thereAreNoMeetupsInTheSystem();
 
         foreach ($table as $row) {
-            $event = new JoindInEvent(
-                (int) $row['id'],
-                $row['title'],
-                new DateTime($row['startDate']),
-                new DateTime($row['endDate'])
-            );
+            $date  = new DateTime($row['date']);
+            $event = new JoindInEvent((int) $row['id'], $row['title'], $date, $date);
 
             $this->getEntityManager()->persist($event);
         }

--- a/features/fetching-joind-in-data.feature
+++ b/features/fetching-joind-in-data.feature
@@ -15,15 +15,15 @@ Feature:
 
   Scenario: It fetches talks from Joind.in meetups we have in our system
     Given we have these meetups in the system
-      | id   | title         | startDate  | endDate    |
-      | 6674 | ZgPHP 2017/10 | 2017-10-19 | 2017-10-19 |
+      | id   | title         | date       |
+      | 6674 | ZgPHP 2017/10 | 2017-10-19 |
     When I fetch meetup talks from Joind.in
     Then there should be 2 talks in system
 
   Scenario: It fetches comments from Joind.in talks we have in our system
     Given we have these meetups in the system
-      | id   | title         | startDate  | endDate    |
-      | 6674 | ZgPHP 2017/10 | 2017-10-19 | 2017-10-19 |
+      | id   | title         | date       |
+      | 6674 | ZgPHP 2017/10 | 2017-10-19 |
     And we have these talks in the system
       | id    | title              | eventId | importedAt          |
       | 22817 | Fullstacking - 101 | 6674    | 2020-01-02 11:22:33 |

--- a/features/raffle/picking-events-to-raffle.feature
+++ b/features/raffle/picking-events-to-raffle.feature
@@ -6,17 +6,17 @@ Feature:
 
   Scenario: Organizer can pick just one meetup to include in raffle
     Given we have these meetups in the system
-      | id | title     | startDate  | endDate    |
-      | 1  | Meetup #1 | 2017-01-19 | 2017-01-19 |
-      | 2  | Meetup #2 | 2017-02-19 | 2017-02-19 |
+      | id | title     | date       |
+      | 1  | Meetup #1 | 2017-01-19 |
+      | 2  | Meetup #2 | 2017-02-19 |
     When organizer picks to raffle meetups: "2"
     Then there should be 1 events on the raffle
 
   Scenario: Organizer can pick multiple meetups to include in raffle
     Given we have these meetups in the system
-      | id | title     | startDate  | endDate    |
-      | 1  | Meetup #1 | 2017-01-19 | 2017-01-19 |
-      | 2  | Meetup #2 | 2017-02-19 | 2017-02-19 |
-      | 3  | Meetup #3 | 2017-03-19 | 2017-03-19 |
+      | id | title     | date       |
+      | 1  | Meetup #1 | 2017-01-19 |
+      | 2  | Meetup #2 | 2017-02-19 |
+      | 3  | Meetup #3 | 2017-03-19 |
     When organizer picks to raffle meetups: "1,3"
     Then there should be 2 events on the raffle

--- a/features/raffling.feature
+++ b/features/raffling.feature
@@ -6,10 +6,10 @@ Feature:
 
   Background:
     Given we have these meetups in the system
-      | id | title     | startDate  | endDate    |
-      | 1  | Meetup #1 | 2017-01-19 | 2017-01-19 |
-      | 2  | Meetup #2 | 2017-02-19 | 2017-02-19 |
-      | 3  | Meetup #3 | 2017-03-19 | 2017-03-19 |
+      | id | title     | date   |
+      | 1  | Meetup #1 | 2017-01-19  |
+      | 2  | Meetup #2 | 2017-02-19  |
+      | 3  | Meetup #3 | 2017-03-19  |
     And we have these talks in the system
       | id  | title    | eventId | importedAt          |
       | 101 | Talk 101 | 1       | 2020-01-02 11:22:33 |


### PR DESCRIPTION
Since all ZgPHP meetups are a one day events, we dont really care about
start and end dates being different. Let's make our scenarios more
readable by using only a date.