### PR TITLE
Remove importedAt from talks in scenarios

### DIFF
--- a/features/bootstrap/FixturesContext.php
+++ b/features/bootstrap/FixturesContext.php
@@ -69,12 +69,7 @@ class FixturesContext extends BaseContext
         foreach ($table as $row) {
             $event = $this->getEventRepository()->find($row['eventId']);
 
-            $talk = new JoindInTalk(
-                (int) $row['id'],
-                $row['title'],
-                $event,
-                new DateTime($row['importedAt'])
-            );
+            $talk = new JoindInTalk((int) $row['id'], $row['title'], $event, new DateTime());
 
             $this->getEntityManager()->persist($talk);
             $event->addTalk($talk);

--- a/features/fetching-joind-in-data.feature
+++ b/features/fetching-joind-in-data.feature
@@ -25,7 +25,7 @@ Feature:
       | id   | title         | date       |
       | 6674 | ZgPHP 2017/10 | 2017-10-19 |
     And we have these talks in the system
-      | id    | title              | eventId | importedAt          |
-      | 22817 | Fullstacking - 101 | 6674    | 2020-01-02 11:22:33 |
+      | id    | title              | eventId |
+      | 22817 | Fullstacking - 101 | 6674    |
     When I fetch meetup talk comments from Joind.in
     Then there should be 1 comment in system

--- a/features/raffling.feature
+++ b/features/raffling.feature
@@ -11,11 +11,11 @@ Feature:
       | 2  | Meetup #2 | 2017-02-19  |
       | 3  | Meetup #3 | 2017-03-19  |
     And we have these talks in the system
-      | id  | title    | eventId | importedAt          |
-      | 101 | Talk 101 | 1       | 2020-01-02 11:22:33 |
-      | 201 | Talk 201 | 2       | 2020-01-02 11:22:33 |
-      | 202 | Talk 202 | 2       | 2020-01-02 11:22:33 |
-      | 301 | Talk 301 | 3       | 2020-01-02 11:22:33 |
+      | id  | title    | eventId |
+      | 101 | Talk 101 | 1       |
+      | 201 | Talk 201 | 2       |
+      | 202 | Talk 202 | 2       |
+      | 301 | Talk 301 | 3       |
     And we have these users in the system
       | id | username | displayName |
       | 1  | User1    | User 1      |


### PR DESCRIPTION
We dont really care when a talk was imported so lets not use them in our scenarios