### PR TITLE
Implicit database cleanup before each scenario

### DIFF
--- a/features/bootstrap/BaseContext.php
+++ b/features/bootstrap/BaseContext.php
@@ -8,10 +8,42 @@ use App\Repository\JoindInTalkRepository;
 use App\Repository\JoindInUserRepository;
 use App\Repository\RaffleRepository;
 use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Doctrine\ORM\EntityManager;
 
 abstract class BaseContext implements Context
 {
+    /**
+     * @BeforeScenario
+     */
+    public function cleanDB(BeforeScenarioScope $scope)
+    {
+        // Remove all meetups, talks & comments.
+        foreach ($this->getEventRepository()->findAll() as $joindInEvent) {
+            foreach ($joindInEvent->getTalks() as $joindInTalk) {
+                foreach ($joindInTalk->getComments() as $joindInComment) {
+                    $this->getEntityManager()->remove($joindInComment);
+                }
+
+                $this->getEntityManager()->remove($joindInTalk);
+            }
+
+            $this->getEntityManager()->remove($joindInEvent);
+        }
+
+        // Remove all raffles.
+        foreach ($this->getRaffleRepository()->findAll() as $raffle) {
+            $this->getEntityManager()->remove($raffle);
+        }
+
+        // Remove all users.
+        foreach ($this->getUserRepository()->findAll() as $user) {
+            $this->getEntityManager()->remove($user);
+        }
+
+        $this->getEntityManager()->flush();
+    }
+
     /**
      * @Transform :user
      */

--- a/features/bootstrap/FixturesContext.php
+++ b/features/bootstrap/FixturesContext.php
@@ -27,31 +27,10 @@ class FixturesContext extends BaseContext
     }
 
     /**
-     * @Given there are no meetups in the system
-     */
-    public function thereAreNoMeetupsInTheSystem()
-    {
-        foreach ($this->getEventRepository()->findAll() as $joindInEvent) {
-            foreach ($joindInEvent->getTalks() as $joindInTalk) {
-                foreach ($joindInTalk->getComments() as $joindInComment) {
-                    $this->getEntityManager()->remove($joindInComment);
-                }
-
-                $this->getEntityManager()->remove($joindInTalk);
-            }
-
-            $this->getEntityManager()->remove($joindInEvent);
-        }
-        $this->getEntityManager()->flush();
-    }
-
-    /**
      * @Given we have these meetups in the system
      */
     public function weHaveThisMeetupsInTheSystem(TableNode $table)
     {
-        $this->thereAreNoMeetupsInTheSystem();
-
         foreach ($table as $row) {
             $date  = new DateTime($row['date']);
             $event = new JoindInEvent((int) $row['id'], $row['title'], $date, $date);
@@ -78,34 +57,10 @@ class FixturesContext extends BaseContext
     }
 
     /**
-     * @Given there are no raffles in the system
-     */
-    public function thereAreNoRafflesInTheSystem()
-    {
-        foreach ($this->getRaffleRepository()->findAll() as $raffle) {
-            $this->getEntityManager()->remove($raffle);
-        }
-        $this->getEntityManager()->flush();
-    }
-
-    /**
-     * @Given there are no users in the system
-     */
-    public function thereAreNoUsersInTheSystem()
-    {
-        foreach ($this->getUserRepository()->findAll() as $user) {
-            $this->getEntityManager()->remove($user);
-        }
-        $this->getEntityManager()->flush();
-    }
-
-    /**
      * @Given we have these users in the system
      */
     public function weHaveThisUsersInTheSystem(TableNode $table)
     {
-        $this->thereAreNoUsersInTheSystem();
-
         foreach ($table as $row) {
             $user = new JoindInUser((int) $row['id'], $row['username'], $row['displayName']);
 

--- a/features/fetching-joind-in-data.feature
+++ b/features/fetching-joind-in-data.feature
@@ -9,7 +9,6 @@ Feature:
   I need to have all meetups,talks and comments in
 
   Scenario: It fetches meetups from Joind.in
-    Given there are no meetups in the system
     When I fetch meetup data from Joind.in
     Then there should be 24 ZgPHP meetups in system
 

--- a/features/raffling.feature
+++ b/features/raffling.feature
@@ -22,7 +22,6 @@ Feature:
       | 2  | User2    | User 2      |
       | 3  | User3    | User 2      |
     And we have each user commenting on each talk
-    And there are no raffles in the system
     And organizer picks to raffle meetups: "2,3"
 
 


### PR DESCRIPTION
Instead of defining cleanup tasks in our scenarios we should clean the
database before each scenario automatically.