### PR TITLE
We can directly json_decode Guzzle's response body, no need to get contents

### DIFF
--- a/spec/Service/JoindInClientSpec.php
+++ b/spec/Service/JoindInClientSpec.php
@@ -15,7 +15,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Psr\Http\Message\StreamInterface;
 
 class JoindInClientSpec extends ObjectBehavior
 {
@@ -32,17 +31,12 @@ class JoindInClientSpec extends ObjectBehavior
     public function it_will_return_zgphp_events(
         Client $client,
         Response $response,
-        StreamInterface $body,
         EventDataFactory $eventDataFactory,
         EventData $eventData
     ) {
         $client->get('https://api.joind.in/v2.1/events?title=zgphp&resultsperpage=30')
             ->shouldBeCalled()
             ->willReturn($response);
-
-        $response->getBody()
-            ->shouldBeCalled()
-            ->willReturn($body);
 
         $content = '
         {
@@ -62,7 +56,7 @@ class JoindInClientSpec extends ObjectBehavior
 }
         ';
 
-        $body->getContents()
+        $response->getBody()
             ->shouldBeCalled()
             ->willReturn($content);
 
@@ -76,18 +70,13 @@ class JoindInClientSpec extends ObjectBehavior
 
     public function it_will_return_empty_array_when_no_events_found(
         Client $client,
-        Response $response,
-        StreamInterface $body
+        Response $response
     ) {
         $client->get('https://api.joind.in/v2.1/events?title=zgphp&resultsperpage=30')
             ->shouldBeCalled()
             ->willReturn($response);
 
         $response->getBody()
-            ->shouldBeCalled()
-            ->willReturn($body);
-
-        $body->getContents()
             ->shouldBeCalled()
             ->willReturn('{"events": []}');
 
@@ -99,7 +88,6 @@ class JoindInClientSpec extends ObjectBehavior
         Client $client,
         TalkDataFactory $talkDataFactory,
         Response $response,
-        StreamInterface $body,
         JoindInEvent $event,
         TalkData $talkData
     ) {
@@ -110,10 +98,6 @@ class JoindInClientSpec extends ObjectBehavior
         $client->get('https://api.joind.in/v2.1/events/2345/talks')
             ->shouldBeCalled()
             ->willReturn($response);
-
-        $response->getBody()
-            ->shouldBeCalled()
-            ->willReturn($body);
 
         $content = '
 {
@@ -136,7 +120,7 @@ class JoindInClientSpec extends ObjectBehavior
 }
         ';
 
-        $body->getContents()
+        $response->getBody()
             ->shouldBeCalled()
             ->willReturn($content);
 
@@ -152,7 +136,6 @@ class JoindInClientSpec extends ObjectBehavior
         Client $client,
         CommentDataFactory $commentDataFactory,
         Response $response,
-        StreamInterface $body,
         JoindInTalk $talk,
         CommentData $commentData
     ) {
@@ -163,10 +146,6 @@ class JoindInClientSpec extends ObjectBehavior
         $client->get('https://api.joind.in/v2.1/talks/2345/comments')
             ->shouldBeCalled()
             ->willReturn($response);
-
-        $response->getBody()
-            ->shouldBeCalled()
-            ->willReturn($body);
 
         $content = '
 {
@@ -183,7 +162,7 @@ class JoindInClientSpec extends ObjectBehavior
 }
         ';
 
-        $body->getContents()
+        $response->getBody()
             ->shouldBeCalled()
             ->willReturn($content);
 

--- a/spec/Service/JoindInTalkRetrievalSpec.php
+++ b/spec/Service/JoindInTalkRetrievalSpec.php
@@ -30,7 +30,6 @@ class JoindInTalkRetrievalSpec extends ObjectBehavior
     public function it_will_add_new_talk_when_fetching_event_talks(
         JoindInClient $joindInClient,
         EntityManager $entityManager,
-        JoindInTalkRepository $talkRepository,
         JoindInEvent $event,
         TalkData $talkData
     ) {

--- a/src/Service/JoindInClient.php
+++ b/src/Service/JoindInClient.php
@@ -44,7 +44,7 @@ class JoindInClient
 
         $response = $this->client->get($url);
 
-        $raw = json_decode($response->getBody()->getContents(), true);
+        $raw = json_decode($response->getBody(), true);
 
         $results = [];
 
@@ -62,7 +62,7 @@ class JoindInClient
 
         $response = $this->client->get($url);
 
-        $raw = json_decode($response->getBody()->getContents(), true);
+        $raw = json_decode($response->getBody(), true);
 
         $results = [];
 
@@ -80,7 +80,7 @@ class JoindInClient
 
         $response = $this->client->get($url);
 
-        $raw = json_decode($response->getBody()->getContents(), true);
+        $raw = json_decode($response->getBody(), true);
 
         $results = [];
 


### PR DESCRIPTION
There was no need to use ->getContent(), just noticed in some checks it works without it as well