### PR TITLE
Declare all PHP files to use strict types

### DIFF
--- a/config/packages/ramsey_uuid_doctrine.yaml
+++ b/config/packages/ramsey_uuid_doctrine.yaml
@@ -1,4 +1,4 @@
 doctrine:
     dbal:
         types:
-            uuid:  Ramsey\Uuid\Doctrine\UuidType
+            uuid:  App\UuidType

--- a/features/bootstrap/BaseContext.php
+++ b/features/bootstrap/BaseContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Entity\JoindInUser;
 use App\Entity\Raffle;
 use App\Repository\JoindInCommentRepository;

--- a/features/bootstrap/FixturesTrait.php
+++ b/features/bootstrap/FixturesTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Entity\JoindInComment;
 use App\Entity\JoindInEvent;
 use App\Entity\JoindInTalk;

--- a/features/bootstrap/JoindInApiContext.php
+++ b/features/bootstrap/JoindInApiContext.php
@@ -80,7 +80,7 @@ class JoindInApiContext extends BaseContext
         $guzzle   = $this->getService(Client::class);
         $response = $guzzle->get($this->testApiUrl.$url);
 
-        return json_decode($response->getBody(), true);
+        return json_decode($response->getBody()->getContents(), true);
     }
 
     protected function getService(string $name)

--- a/features/bootstrap/JoindInApiContext.php
+++ b/features/bootstrap/JoindInApiContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use GuzzleHttp\Client;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Webmozart\Assert\Assert;

--- a/features/bootstrap/JoindInContext.php
+++ b/features/bootstrap/JoindInContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Service\JoindInCommentRetrieval;
 use App\Service\JoindInEventRetrieval;
 use App\Service\JoindInTalkRetrieval;

--- a/features/bootstrap/RaffleApiContext.php
+++ b/features/bootstrap/RaffleApiContext.php
@@ -181,14 +181,14 @@ class RaffleApiContext extends BaseContext
     {
         $response = $this->getGuzzle()->get($this->testApiUrl.$url);
 
-        return json_decode($response->getBody(), true);
+        return json_decode($response->getBody()->getContents(), true);
     }
 
     private function apiPostJson(string $url, array $options = [])
     {
         $response = $this->getGuzzle()->post($this->testApiUrl.$url, $options);
 
-        return json_decode($response->getBody(), true);
+        return json_decode($response->getBody()->getContents(), true);
     }
 
     private function getGuzzle(): Client

--- a/features/bootstrap/RaffleApiContext.php
+++ b/features/bootstrap/RaffleApiContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Entity\JoindInUser;
 use GuzzleHttp\Client;
 use Symfony\Component\HttpKernel\KernelInterface;

--- a/features/bootstrap/RaffleContext.php
+++ b/features/bootstrap/RaffleContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Entity\JoindInUser;
 use App\Entity\Raffle;
 use App\Exception\NoCommentsToRaffleException;

--- a/features/bootstrap/bootstrap.php
+++ b/features/bootstrap/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Symfony\Component\Dotenv\Dotenv;
 
 // The check is to ensure we don't use .env in production

--- a/spec/JoindIn/CommentDataFactorySpec.php
+++ b/spec/JoindIn/CommentDataFactorySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\App\JoindIn;
 
 use App\Entity\JoindInTalk;

--- a/spec/JoindIn/CommentDataSpec.php
+++ b/spec/JoindIn/CommentDataSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\App\JoindIn;
 
 use App\Entity\JoindInTalk;

--- a/spec/JoindIn/EventDataFactorySpec.php
+++ b/spec/JoindIn/EventDataFactorySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\App\JoindIn;
 
 use App\JoindIn\EventData;

--- a/spec/JoindIn/EventDataSpec.php
+++ b/spec/JoindIn/EventDataSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\App\JoindIn;
 
 use App\JoindIn\EventData;

--- a/spec/JoindIn/TalkDataFactorySpec.php
+++ b/spec/JoindIn/TalkDataFactorySpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\App\JoindIn;
 
 use App\Entity\JoindInEvent;

--- a/spec/JoindIn/TalkDataSpec.php
+++ b/spec/JoindIn/TalkDataSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\App\JoindIn;
 
 use App\Entity\JoindInEvent;

--- a/spec/JoindIn/UserDataSpec.php
+++ b/spec/JoindIn/UserDataSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\App\JoindIn;
 
 use App\JoindIn\UserData;

--- a/spec/Service/JoindInClientSpec.php
+++ b/spec/Service/JoindInClientSpec.php
@@ -15,6 +15,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Psr\Http\Message\StreamInterface;
 
 class JoindInClientSpec extends ObjectBehavior
 {
@@ -31,12 +32,17 @@ class JoindInClientSpec extends ObjectBehavior
     public function it_will_return_zgphp_events(
         Client $client,
         Response $response,
+        StreamInterface $body,
         EventDataFactory $eventDataFactory,
         EventData $eventData
     ) {
         $client->get('https://api.joind.in/v2.1/events?title=zgphp&resultsperpage=30')
             ->shouldBeCalled()
             ->willReturn($response);
+
+        $response->getBody()
+            ->shouldBeCalled()
+            ->willReturn($body);
 
         $content = '
         {
@@ -56,7 +62,7 @@ class JoindInClientSpec extends ObjectBehavior
 }
         ';
 
-        $response->getBody()
+        $body->getContents()
             ->shouldBeCalled()
             ->willReturn($content);
 
@@ -70,13 +76,18 @@ class JoindInClientSpec extends ObjectBehavior
 
     public function it_will_return_empty_array_when_no_events_found(
         Client $client,
-        Response $response
+        Response $response,
+        StreamInterface $body
     ) {
         $client->get('https://api.joind.in/v2.1/events?title=zgphp&resultsperpage=30')
             ->shouldBeCalled()
             ->willReturn($response);
 
         $response->getBody()
+            ->shouldBeCalled()
+            ->willReturn($body);
+
+        $body->getContents()
             ->shouldBeCalled()
             ->willReturn('{"events": []}');
 
@@ -88,6 +99,7 @@ class JoindInClientSpec extends ObjectBehavior
         Client $client,
         TalkDataFactory $talkDataFactory,
         Response $response,
+        StreamInterface $body,
         JoindInEvent $event,
         TalkData $talkData
     ) {
@@ -98,6 +110,10 @@ class JoindInClientSpec extends ObjectBehavior
         $client->get('https://api.joind.in/v2.1/events/2345/talks')
             ->shouldBeCalled()
             ->willReturn($response);
+
+        $response->getBody()
+            ->shouldBeCalled()
+            ->willReturn($body);
 
         $content = '
 {
@@ -120,7 +136,7 @@ class JoindInClientSpec extends ObjectBehavior
 }
         ';
 
-        $response->getBody()
+        $body->getContents()
             ->shouldBeCalled()
             ->willReturn($content);
 
@@ -136,6 +152,7 @@ class JoindInClientSpec extends ObjectBehavior
         Client $client,
         CommentDataFactory $commentDataFactory,
         Response $response,
+        StreamInterface $body,
         JoindInTalk $talk,
         CommentData $commentData
     ) {
@@ -146,6 +163,10 @@ class JoindInClientSpec extends ObjectBehavior
         $client->get('https://api.joind.in/v2.1/talks/2345/comments')
             ->shouldBeCalled()
             ->willReturn($response);
+
+        $response->getBody()
+            ->shouldBeCalled()
+            ->willReturn($body);
 
         $content = '
 {
@@ -162,7 +183,7 @@ class JoindInClientSpec extends ObjectBehavior
 }
         ';
 
-        $response->getBody()
+        $body->getContents()
             ->shouldBeCalled()
             ->willReturn($content);
 

--- a/spec/Service/JoindInClientSpec.php
+++ b/spec/Service/JoindInClientSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\App\Service;
 
 use App\Entity\JoindInEvent;

--- a/spec/Service/JoindInCommentRetrievalSpec.php
+++ b/spec/Service/JoindInCommentRetrievalSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\App\Service;
 
 use App\Entity\JoindInComment;

--- a/spec/Service/JoindInEventRetrievalSpec.php
+++ b/spec/Service/JoindInEventRetrievalSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\App\Service;
 
 use App\Entity\JoindInEvent;

--- a/spec/Service/JoindInTalkRetrievalSpec.php
+++ b/spec/Service/JoindInTalkRetrievalSpec.php
@@ -30,6 +30,7 @@ class JoindInTalkRetrievalSpec extends ObjectBehavior
     public function it_will_add_new_talk_when_fetching_event_talks(
         JoindInClient $joindInClient,
         EntityManager $entityManager,
+        JoindInTalkRepository $talkRepository,
         JoindInEvent $event,
         TalkData $talkData
     ) {

--- a/spec/Service/JoindInTalkRetrievalSpec.php
+++ b/spec/Service/JoindInTalkRetrievalSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\App\Service;
 
 use App\Entity\JoindInEvent;

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Controller/JoindInCommentController.php
+++ b/src/Controller/JoindInCommentController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use App\Repository\JoindInCommentRepository;

--- a/src/Controller/JoindInEventController.php
+++ b/src/Controller/JoindInEventController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use App\Repository\JoindInEventRepository;

--- a/src/Controller/JoindInTalkController.php
+++ b/src/Controller/JoindInTalkController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use App\Repository\JoindInEventRepository;

--- a/src/Controller/RaffleApiController.php
+++ b/src/Controller/RaffleApiController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use App\Entity\JoindInUser;

--- a/src/Entity/JoindInComment.php
+++ b/src/Entity/JoindInComment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/src/Entity/JoindInEvent.php
+++ b/src/Entity/JoindInEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity;
 
 use DateTime;

--- a/src/Entity/JoindInTalk.php
+++ b/src/Entity/JoindInTalk.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity;
 
 use DateTime;

--- a/src/Entity/JoindInUser.php
+++ b/src/Entity/JoindInUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/src/Entity/Raffle.php
+++ b/src/Entity/Raffle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity;
 
 use App\Exception\NoCommentsToRaffleException;

--- a/src/Exception/NoCommentsToRaffleException.php
+++ b/src/Exception/NoCommentsToRaffleException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exception;
 
 use DomainException;

--- a/src/JoindIn/CommentData.php
+++ b/src/JoindIn/CommentData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\JoindIn;
 
 use App\Entity\JoindInTalk;

--- a/src/JoindIn/CommentDataFactory.php
+++ b/src/JoindIn/CommentDataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\JoindIn;
 
 use App\Entity\JoindInTalk;

--- a/src/JoindIn/EventData.php
+++ b/src/JoindIn/EventData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\JoindIn;
 
 use DateTime;

--- a/src/JoindIn/EventDataFactory.php
+++ b/src/JoindIn/EventDataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\JoindIn;
 
 class EventDataFactory

--- a/src/JoindIn/TalkData.php
+++ b/src/JoindIn/TalkData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\JoindIn;
 
 use App\Entity\JoindInEvent;

--- a/src/JoindIn/TalkDataFactory.php
+++ b/src/JoindIn/TalkDataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\JoindIn;
 
 use App\Entity\JoindInEvent;

--- a/src/JoindIn/UserData.php
+++ b/src/JoindIn/UserData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\JoindIn;
 
 class UserData

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;

--- a/src/Migrations/Version20171102142529.php
+++ b/src/Migrations/Version20171102142529.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/src/Migrations/Version20171102223552.php
+++ b/src/Migrations/Version20171102223552.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/src/Migrations/Version20171102224527.php
+++ b/src/Migrations/Version20171102224527.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/src/Migrations/Version20171103224656.php
+++ b/src/Migrations/Version20171103224656.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/src/Migrations/Version20171104122657.php
+++ b/src/Migrations/Version20171104122657.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/src/Migrations/Version20171104123424.php
+++ b/src/Migrations/Version20171104123424.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/src/Migrations/Version20171104183806.php
+++ b/src/Migrations/Version20171104183806.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/src/Repository/JoindInCommentRepository.php
+++ b/src/Repository/JoindInCommentRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use Doctrine\ORM\EntityRepository;

--- a/src/Repository/JoindInEventRepository.php
+++ b/src/Repository/JoindInEventRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use Doctrine\ORM\EntityRepository;

--- a/src/Repository/JoindInTalkRepository.php
+++ b/src/Repository/JoindInTalkRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use Doctrine\ORM\EntityRepository;

--- a/src/Repository/JoindInUserRepository.php
+++ b/src/Repository/JoindInUserRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use Doctrine\ORM\EntityRepository;

--- a/src/Repository/RaffleRepository.php
+++ b/src/Repository/RaffleRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use Doctrine\ORM\EntityRepository;

--- a/src/Service/JoindInClient.php
+++ b/src/Service/JoindInClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
 use App\Entity\JoindInEvent;

--- a/src/Service/JoindInClient.php
+++ b/src/Service/JoindInClient.php
@@ -44,7 +44,7 @@ class JoindInClient
 
         $response = $this->client->get($url);
 
-        $raw = json_decode($response->getBody(), true);
+        $raw = json_decode($response->getBody()->getContents(), true);
 
         $results = [];
 
@@ -62,7 +62,7 @@ class JoindInClient
 
         $response = $this->client->get($url);
 
-        $raw = json_decode($response->getBody(), true);
+        $raw = json_decode($response->getBody()->getContents(), true);
 
         $results = [];
 
@@ -80,7 +80,7 @@ class JoindInClient
 
         $response = $this->client->get($url);
 
-        $raw = json_decode($response->getBody(), true);
+        $raw = json_decode($response->getBody()->getContents(), true);
 
         $results = [];
 

--- a/src/Service/JoindInCommentRetrieval.php
+++ b/src/Service/JoindInCommentRetrieval.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
 use App\Entity\JoindInComment;

--- a/src/Service/JoindInEventRetrieval.php
+++ b/src/Service/JoindInEventRetrieval.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
 use App\Entity\JoindInEvent;

--- a/src/Service/JoindInTalkRetrieval.php
+++ b/src/Service/JoindInTalkRetrieval.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
 use App\Entity\JoindInEvent;

--- a/src/UuidType.php
+++ b/src/UuidType.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * This file is part of the ramsey/uuid-doctrine library.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Ben Ramsey <http://benramsey.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @see https://packagist.org/packages/ramsey/uuid-doctrine Packagist
+ * @see https://github.com/ramsey/uuid-doctrine GitHub
+ */
+
+namespace App;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * Field type mapping for the Doctrine Database Abstraction Layer (DBAL).
+ *
+ * UUID fields will be stored as a string in the database and converted back to
+ * the Uuid value object when querying.
+ */
+class UuidType extends Type
+{
+    /**
+     * @var string
+     */
+    const NAME = 'uuid';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array                                     $fieldDeclaration
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     */
+    public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getGuidTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param string|null                               $value
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     */
+    public function convertToPhpValue($value, AbstractPlatform $platform)
+    {
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param UuidInterface|null                        $value
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        if ($value instanceof Uuid || Uuid::isValid($value)) {
+            return (string) $value;
+        }
+
+        throw ConversionException::conversionFailed($value, static::NAME);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return static::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     *
+     * @return bool
+     */
+    public function requiresSqlCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+}

--- a/src/UuidType.php
+++ b/src/UuidType.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * This file is part of the ramsey/uuid-doctrine library.
  *


### PR DESCRIPTION
We want to enforce better coding and found few issues due to improvements:

1) reverts are needed on json_decode changes, while it did work without call to getContents() it was abusing the type system
2) when loading a raffle from database, id would be loaded as UUID object which started breaking the app so I copyed over UuidType and fixed what it returns

Closes #99