### PR TITLE
Move BaseContext to HelperTrait

### DIFF
--- a/features/bootstrap/HelperTrait.php
+++ b/features/bootstrap/HelperTrait.php
@@ -9,11 +9,10 @@ use App\Repository\JoindInEventRepository;
 use App\Repository\JoindInTalkRepository;
 use App\Repository\JoindInUserRepository;
 use App\Repository\RaffleRepository;
-use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Doctrine\ORM\EntityManager;
 
-abstract class BaseContext implements Context
+trait HelperTrait
 {
     /**
      * @BeforeScenario
@@ -99,6 +98,4 @@ abstract class BaseContext implements Context
     {
         return $this->getService(RaffleRepository::class);
     }
-
-    abstract protected function getService(string $name);
 }

--- a/features/bootstrap/JoindInApiContext.php
+++ b/features/bootstrap/JoindInApiContext.php
@@ -2,13 +2,16 @@
 
 declare(strict_types=1);
 
+use Behat\Behat\Context\Context;
 use GuzzleHttp\Client;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Webmozart\Assert\Assert;
 
-class JoindInApiContext extends BaseContext
+class JoindInApiContext implements Context
 {
     use FixturesTrait;
+    use HelperTrait;
+
     /**
      * @var KernelInterface
      */

--- a/features/bootstrap/JoindInContext.php
+++ b/features/bootstrap/JoindInContext.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 use App\Service\JoindInCommentRetrieval;
 use App\Service\JoindInEventRetrieval;
 use App\Service\JoindInTalkRetrieval;
+use Behat\Behat\Context\Context;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Webmozart\Assert\Assert;
 
-class JoindInContext extends BaseContext
+class JoindInContext implements Context
 {
     use FixturesTrait;
+    use HelperTrait;
 
     /** @var KernelInterface */
     private $kernel;

--- a/features/bootstrap/RaffleApiContext.php
+++ b/features/bootstrap/RaffleApiContext.php
@@ -3,13 +3,15 @@
 declare(strict_types=1);
 
 use App\Entity\JoindInUser;
+use Behat\Behat\Context\Context;
 use GuzzleHttp\Client;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Webmozart\Assert\Assert;
 
-class RaffleApiContext extends BaseContext
+class RaffleApiContext implements Context
 {
     use FixturesTrait;
+    use HelperTrait;
 
     /** @var KernelInterface */
     private $kernel;

--- a/features/bootstrap/RaffleContext.php
+++ b/features/bootstrap/RaffleContext.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 use App\Entity\JoindInUser;
 use App\Entity\Raffle;
 use App\Exception\NoCommentsToRaffleException;
+use Behat\Behat\Context\Context;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Webmozart\Assert\Assert;
 
-class RaffleContext extends BaseContext
+class RaffleContext implements Context
 {
     use FixturesTrait;
+    use HelperTrait;
 
     /** @var KernelInterface */
     private $kernel;


### PR DESCRIPTION
In order to have cleaner inheritance tree
For maintainers
We will stop using BaseContext as parent class and use trait
Whereas we are blocking usage of other contexts that would be very helpfull in the future

Closes #105