### PR TITLE
103 - Refactor Behat fixtures for db cleanup

### DIFF
--- a/features/bootstrap/HelperTrait.php
+++ b/features/bootstrap/HelperTrait.php
@@ -21,14 +21,6 @@ trait HelperTrait
     {
         // Remove all meetups, talks & comments.
         foreach ($this->getEventRepository()->findAll() as $joindInEvent) {
-            foreach ($joindInEvent->getTalks() as $joindInTalk) {
-                foreach ($joindInTalk->getComments() as $joindInComment) {
-                    $this->getEntityManager()->remove($joindInComment);
-                }
-
-                $this->getEntityManager()->remove($joindInTalk);
-            }
-
             $this->getEntityManager()->remove($joindInEvent);
         }
 

--- a/src/Entity/JoindInComment.php
+++ b/src/Entity/JoindInComment.php
@@ -44,6 +44,7 @@ class JoindInComment implements \JsonSerializable
 
     /**
      * @ORM\ManyToOne(targetEntity="App\Entity\JoindInTalk", inversedBy="comments")
+     * @ORM\JoinColumn(onDelete="CASCADE")
      *
      * @var JoindInTalk
      */

--- a/src/Entity/JoindInTalk.php
+++ b/src/Entity/JoindInTalk.php
@@ -33,6 +33,7 @@ class JoindInTalk implements \JsonSerializable
 
     /**
      * @ORM\ManyToOne(targetEntity="App\Entity\JoindInEvent", inversedBy="talks")
+     * @ORM\JoinColumn(onDelete="CASCADE")
      *
      * @var JoindInEvent
      */

--- a/src/Migrations/Version20171111002932.php
+++ b/src/Migrations/Version20171111002932.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171111002932 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is modified to preserve the 'enddate' column, which still holds orphan data
+        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE joindincomments DROP CONSTRAINT FK_FA3AD44E6F0601D5');
+        $this->addSql('ALTER TABLE joindincomments ADD CONSTRAINT FK_FA3AD44E6F0601D5 FOREIGN KEY (talk_id) REFERENCES joindinTalks (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE joindintalks DROP CONSTRAINT FK_FB7FC5EA71F7E88B');
+        $this->addSql('ALTER TABLE joindintalks ADD CONSTRAINT FK_FB7FC5EA71F7E88B FOREIGN KEY (event_id) REFERENCES joindinEvents (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is modified so as not to recreate the 'enddate' column, which still holds orphan data
+        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE joindinTalks DROP CONSTRAINT fk_fb7fc5ea71f7e88b');
+        $this->addSql('ALTER TABLE joindinTalks ADD CONSTRAINT fk_fb7fc5ea71f7e88b FOREIGN KEY (event_id) REFERENCES joindinevents (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE joindinComments DROP CONSTRAINT fk_fa3ad44e6f0601d5');
+        $this->addSql('ALTER TABLE joindinComments ADD CONSTRAINT fk_fa3ad44e6f0601d5 FOREIGN KEY (talk_id) REFERENCES joindintalks (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+}


### PR DESCRIPTION
Defined FK cascade delete operation on Talk and Comment, generated the migration file, and refactored the db clean up scenario in Behat to make use of this new ability, whereas until now it was looping through events in order to get talks, and then doing the same thing to get comments.

Users are left intact, as agreed.

Will open a new issue for adding tests/scenarios to make sure the users are still in system after this cleanup.

Closes #103 