### PR TITLE
111 - Run schema validation on every build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -76,4 +76,12 @@
         <exec command="bin/console doctrine:fixtures:load --verbose --append --env=test" passthru="true"/>
     </target>
 
+    <target name="check-test-schema" description="Check test db schema">
+        <exec command="bin/console doctrine:schema:validate --env=test" passthru="true" checkreturn="true"/>
+    </target>
+
+    <target name="check-dev-schema" description="Check dev db schema">
+        <exec command="bin/console doctrine:schema:validate --env=dev" passthru="true" checkreturn="true"/>
+    </target>
+
 </project>

--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,10 @@ jobs:
           command: ./vendor/bin/phing refresh-test-db
 
       - run:
+          name: Validate database schema
+          command: ./vendor/bin/phing check-test-schema
+
+      - run:
           name: Lint all PHP code files
           command: find src/ -type f -name "*.php" -print0 | xargs -0 -n1 php -l
 


### PR DESCRIPTION
Created a new build step for running db schema validation, but excluded it from the master ```test``` command (can be run manually, though).

I've also added it CircleCI build definition.
Tests fail, and will continue to fail, until we decide what to do (and how to handle) the orphan column ```enddate``` in events table.

Closes #111 