### PR TITLE
Track codecoverage in PHPUnit

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -57,6 +57,9 @@ jobs:
           key: cache-v4-{{ checksum "composer.lock" }}
           paths:
             - /var/www/vendor
+      - run:
+          name: Ship codecoverage to codecov.io
+          command: bash <(curl -s https://codecov.io/bash)      
 
 workflows:
   version: 2

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,4 +28,16 @@
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+
+    <logging>
+        <log type="coverage-php" target="coverage.cov"/>
+        <log type="coverage-clover" target="clover.xml"/>
+        <log type="coverage-html" target="build/phpunit"/>
+    </logging>
+
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
In order to find pieces of code that are missing tests
For maintainers
We want to track PHPUnit code coverage

Reports are visible [on codecov.io](https://codecov.io/gh/zgphp/joindin-raffler-backend/)