### PR TITLE
Remove existing schema creation command

### DIFF
--- a/src/Migrations/Version20171102142529.php
+++ b/src/Migrations/Version20171102142529.php
@@ -28,10 +28,9 @@ class Version20171102142529 extends AbstractMigration
      */
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
+        // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
 
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('DROP TABLE joindinEvents');
     }
 }

--- a/src/Migrations/Version20171102223552.php
+++ b/src/Migrations/Version20171102223552.php
@@ -29,10 +29,9 @@ class Version20171102223552 extends AbstractMigration
      */
     public function down(Schema $schema)
     {
-        // this down() migration is auto-generated, please modify it to your needs
+        // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
 
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE joindinEvents DROP startDate');
         $this->addSql('ALTER TABLE joindinEvents DROP endDate');
     }

--- a/src/Migrations/Version20171102224527.php
+++ b/src/Migrations/Version20171102224527.php
@@ -29,10 +29,9 @@ class Version20171102224527 extends AbstractMigration
      */
     public function down(Schema $schema)
     {
-        // this down() migration is auto-generated, please modify it to your needs
+        // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
 
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE joindinEvents ALTER startDate DROP NOT NULL');
         $this->addSql('ALTER TABLE joindinEvents ALTER endDate DROP NOT NULL');
     }

--- a/src/Migrations/Version20171103224656.php
+++ b/src/Migrations/Version20171103224656.php
@@ -30,10 +30,9 @@ class Version20171103224656 extends AbstractMigration
      */
     public function down(Schema $schema)
     {
-        // this down() migration is auto-generated, please modify it to your needs
+        // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
 
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('DROP TABLE joindinTalks');
     }
 }

--- a/src/Migrations/Version20171104122657.php
+++ b/src/Migrations/Version20171104122657.php
@@ -28,10 +28,9 @@ class Version20171104122657 extends AbstractMigration
      */
     public function down(Schema $schema)
     {
-        // this down() migration is auto-generated, please modify it to your needs
+        // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
 
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('DROP TABLE joindinUsers');
     }
 }

--- a/src/Migrations/Version20171104123424.php
+++ b/src/Migrations/Version20171104123424.php
@@ -32,10 +32,9 @@ class Version20171104123424 extends AbstractMigration
      */
     public function down(Schema $schema)
     {
-        // this down() migration is auto-generated, please modify it to your needs
+        // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
 
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('DROP TABLE joindinComments');
     }
 }

--- a/src/Migrations/Version20171104183806.php
+++ b/src/Migrations/Version20171104183806.php
@@ -47,10 +47,9 @@ class Version20171104183806 extends AbstractMigration
      */
     public function down(Schema $schema)
     {
-        // this down() migration is auto-generated, please modify it to your needs
+        // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
 
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE raffleEvents DROP CONSTRAINT FK_6A5D398CDBEC4B1F');
         $this->addSql('ALTER TABLE raffleWinners DROP CONSTRAINT FK_8E84A987DBEC4B1F');
         $this->addSql('ALTER TABLE raffleNoShows DROP CONSTRAINT FK_A6A1C1FFDBEC4B1F');

--- a/src/Migrations/Version20171108224445.php
+++ b/src/Migrations/Version20171108224445.php
@@ -28,11 +28,11 @@ class Version20171108224445 extends AbstractMigration
      */
     public function down(Schema $schema)
     {
-        // this down() migration is modified to preserve the already present data in table and revert the the column
-        // name and null value acceptance
+        // this down() migration is modified to preserve the already present data in table, revert the the column
+        // name and null value acceptance, and to not try to recreate an existing 'public' schema
+
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
 
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE joindinEvents RENAME COLUMN date TO startdate');
         $this->addSql('ALTER TABLE joindinevents ALTER COLUMN enddate SET NOT NULL;');
     }


### PR DESCRIPTION
Rolling back a migration would fail due to PGSQL trying to recreate an already existing schema.

This removes the sql that tries to recreate the schema in down() migrations across all the migration version files.

Tests pass, but none of our tests actually test to see if a migration rollback is possible.
This can be merged into master, but rollbacks still will not work, due to orphaned table column (see #120 for details).

Not sure what the best practices are for these kinds of situations - (can|should|how do) we write tests for migration rollbacks?

Closes #110 