### PR TITLE
#120 - Remove unused enddate column in joindinevents table

### DIFF
--- a/src/Migrations/Version20171111192937.php
+++ b/src/Migrations/Version20171111192937.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171111192937 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE joindinevents DROP enddate');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE joindinEvents ADD enddate TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+    }
+}


### PR DESCRIPTION
Unused enddate column caused schema to be out of sync with relations
declared between entities on code level, and blocked migration rollbacks
(see issue #120 for details).

Closes #120 

~~NOTE:~~
~~PR #116 will have to be rebased with master after this is merged in, and will have a lot of conflicts that will need to be resolved.~~

