### PR TITLE
Remove schema recreation in migration files

### DIFF
--- a/src/Migrations/Version20171111002932.php
+++ b/src/Migrations/Version20171111002932.php
@@ -29,10 +29,9 @@ class Version20171111002932 extends AbstractMigration
      */
     public function down(Schema $schema)
     {
-        // this down() migration is modified so as not to recreate the 'enddate' column, which still holds orphan data
+        // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
 
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE joindinTalks DROP CONSTRAINT fk_fb7fc5ea71f7e88b');
         $this->addSql('ALTER TABLE joindinTalks ADD CONSTRAINT fk_fb7fc5ea71f7e88b FOREIGN KEY (event_id) REFERENCES joindinevents (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->addSql('ALTER TABLE joindinComments DROP CONSTRAINT fk_fa3ad44e6f0601d5');

--- a/src/Migrations/Version20171111192937.php
+++ b/src/Migrations/Version20171111192937.php
@@ -26,10 +26,9 @@ class Version20171111192937 extends AbstractMigration
      */
     public function down(Schema $schema)
     {
-        // this down() migration is auto-generated, please modify it to your needs
+        // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
 
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE joindinEvents ADD enddate TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
     }
 }


### PR DESCRIPTION
Some migration files sliped through with schema recreation commands
still in. This will clean them up.

Doctrine always adds this command, so until we learn how to disable
it, we'll need to manually remove it from down() migrations.

Closes #123 