### PR TITLE
Define business rule for skipping organizer comments

### DIFF
--- a/features/raffle/raffling.feature
+++ b/features/raffle/raffling.feature
@@ -24,3 +24,17 @@ Feature:
     And organizer picks to raffle meetups: "1"
     When I pick a winner
     Then we should get one of "User1,User2" as a winner
+
+  Scenario: Organizer's comments will not be eligible for raffle
+    Given we have these meetups in the system
+      | id | title     | date       |
+      | 1  | Meetup #1 | 2017-01-19 |
+    And we have these talks in the system
+      | id | title             | eventId |
+      | 10 | Talk on meetup #1 | 1       |
+    And we have these users in the system
+      | id    | username   | displayName |
+      | 18486 | Organizer1 | Organizer 1 |
+    And we have each user commenting on each talk
+    When organizer picks to raffle meetups: "1"
+    Then there should be 0 comments on the raffle

--- a/src/Entity/Raffle.php
+++ b/src/Entity/Raffle.php
@@ -158,6 +158,9 @@ class Raffle implements \JsonSerializable
      */
     private function userAlreadyWonOrIsNoShow(JoindInUser $user): bool
     {
+        if (in_array($user->getId(), [18486, 31686])) {
+            return true;
+        }
         foreach ($this->winners as $winner) {
             if ($winner === $user) {
                 return true;


### PR DESCRIPTION
Since Organizers comments are not eligible for raffle, we need to add
a rule to our feature files and implement business logic that discards
them.

Part of WIP series for issues #78 

