### PR TITLE
#78 - Organizers are not eligible to win prizes

### DIFF
--- a/features/bootstrap/JoindInFixturesTrait.php
+++ b/features/bootstrap/JoindInFixturesTrait.php
@@ -46,7 +46,8 @@ trait JoindInFixturesTrait
     public function weHaveTheseUsersInTheSystem(TableNode $table)
     {
         foreach ($table as $row) {
-            $user = new JoindInUser((int) $row['id'], $row['username'], $row['displayName']);
+            $isOrganizer = 'true' === $row['organizer'] ? true : false;
+            $user        = new JoindInUser((int) $row['id'], $row['username'], $row['displayName'], $isOrganizer);
 
             $this->getEntityManager()->persist($user);
         }

--- a/features/raffle/no-shows.feature
+++ b/features/raffle/no-shows.feature
@@ -12,9 +12,9 @@ Feature:
       | id | title             | eventId |
       | 10 | Talk on meetup #1 | 1       |
     And we have these users in the system
-      | id | username | displayName |
-      | 1  | User1    | User 1      |
-      | 2  | User2    | User 2      |
+      | id | username | displayName | organizer |
+      | 1  | User1    | User 1      | false     |
+      | 2  | User2    | User 2      | false     |
     And we have each user commenting on each talk
     And organizer picks to raffle meetups: "1"
 

--- a/features/raffle/raffling.feature
+++ b/features/raffle/raffling.feature
@@ -17,9 +17,9 @@ Feature:
       | id | title             | eventId |
       | 10 | Talk on meetup #1 | 1       |
     And we have these users in the system
-      | id | username | displayName |
-      | 1  | User1    | User 1      |
-      | 2  | User2    | User 2      |
+      | id | username | displayName | organizer |
+      | 1  | User1    | User 1      | false     |
+      | 2  | User2    | User 2      | false     |
     And we have each user commenting on each talk
     And organizer picks to raffle meetups: "1"
     When I pick a winner
@@ -33,8 +33,8 @@ Feature:
       | id | title             | eventId |
       | 10 | Talk on meetup #1 | 1       |
     And we have these users in the system
-      | id    | username   | displayName |
-      | 18486 | Organizer1 | Organizer 1 |
+      | id    | username   | displayName | organizer  |
+      | 18486 | Organizer1 | Organizer 1 | true       |
     And we have each user commenting on each talk
     When organizer picks to raffle meetups: "1"
     Then there should be 0 comments on the raffle

--- a/features/raffle/winner.feature
+++ b/features/raffle/winner.feature
@@ -12,9 +12,9 @@ Feature:
       | id | title             | eventId |
       | 10 | Talk on meetup #1 | 1       |
     And we have these users in the system
-      | id | username | displayName |
-      | 1  | User1    | User 1      |
-      | 2  | User2    | User 2      |
+      | id | username | displayName | organizer |
+      | 1  | User1    | User 1      | false     |
+      | 2  | User2    | User 2      | false     |
     And we have each user commenting on each talk
     And organizer picks to raffle meetups: "1"
 

--- a/features/raffling.feature
+++ b/features/raffling.feature
@@ -17,10 +17,10 @@ Feature:
       | 202 | Talk 202 | 2       |
       | 301 | Talk 301 | 3       |
     And we have these users in the system
-      | id | username | displayName |
-      | 1  | User1    | User 1      |
-      | 2  | User2    | User 2      |
-      | 3  | User3    | User 2      |
+      | id | username | displayName | organizer |
+      | 1  | User1    | User 1      | false     |
+      | 2  | User2    | User 2      | false     |
+      | 3  | User3    | User 2      | false     |
     And we have each user commenting on each talk
     And organizer picks to raffle meetups: "2,3"
 

--- a/src/DataFixtures/ORM/JoindInUsersFixtures.php
+++ b/src/DataFixtures/ORM/JoindInUsersFixtures.php
@@ -14,8 +14,10 @@ class JoindInUsersFixtures extends AbstractFixture implements OrderedFixtureInte
     public function load(ObjectManager $manager)
     {
         $users = [
-            'user1' => new JoindInUser(45128, 'username1', 'User Named One'),
-            'user2' => new JoindInUser(26764, 'username2', 'User Named Two'),
+            'user1'      => new JoindInUser(45128, 'username1', 'User Named One', false),
+            'user2'      => new JoindInUser(26764, 'username2', 'User Named Two', false),
+            'organizer1' => new JoindInUser(18486, 'organizer1', 'Organizer Primus', true),
+            'organizer2' => new JoindInUser(31686, 'organizer2', 'Organizer Secundus', true),
         ];
 
         foreach ($users as $userRef => $user) {

--- a/src/Entity/JoindInUser.php
+++ b/src/Entity/JoindInUser.php
@@ -35,6 +35,12 @@ class JoindInUser implements \JsonSerializable
      * @var string
      */
     private $displayName;
+    /**
+     * @ORM\Column(type="boolean", nullable=false, options={"default":false})
+     *
+     * @var bool
+     */
+    private $organizer;
 
     /**
      * @var \Doctrine\Common\Collections\ArrayCollection
@@ -42,21 +48,12 @@ class JoindInUser implements \JsonSerializable
      */
     private $comments;
 
-    public function __construct(int $id, string $username, string $displayName)
+    public function __construct(int $id, string $username, string $displayName, bool $isOrganizer = false)
     {
         $this->id          = $id;
         $this->username    = $username;
         $this->displayName = $displayName;
-    }
-
-    public function setUsername(string $username)
-    {
-        $this->username = $username;
-    }
-
-    public function setDisplayName(string $displayName)
-    {
-        $this->displayName = $displayName;
+        $this->organizer   = $isOrganizer;
     }
 
     public function getId(): int
@@ -69,9 +66,19 @@ class JoindInUser implements \JsonSerializable
         return $this->username;
     }
 
+    public function setUsername(string $username)
+    {
+        $this->username = $username;
+    }
+
     public function getDisplayName(): string
     {
         return $this->displayName;
+    }
+
+    public function setDisplayName(string $displayName)
+    {
+        $this->displayName = $displayName;
     }
 
     public function jsonSerialize(): array
@@ -97,5 +104,18 @@ class JoindInUser implements \JsonSerializable
     public function addComment(JoindInComment $comment)
     {
         $this->comments->add($comment);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isOrganizer(): bool
+    {
+        return $this->organizer;
+    }
+
+    public function promoteToOrganizer()
+    {
+        $this->organizer = true;
     }
 }

--- a/src/Entity/Raffle.php
+++ b/src/Entity/Raffle.php
@@ -95,7 +95,7 @@ class Raffle implements \JsonSerializable
             foreach ($event->getTalks() as $talk) {
                 /** @var \App\Entity\JoindInComment $comment */
                 foreach ($talk->getComments() as $comment) {
-                    if (false === $this->userAlreadyWonOrIsNoShow($comment->getUser())) {
+                    if (true === $this->userIsEligibleForRaffle($comment->getUser())) {
                         $comments->add($comment);
                     }
                 }
@@ -156,23 +156,23 @@ class Raffle implements \JsonSerializable
      * Checks if that commenter is already a winner or a no show so we can easily filter out which comments are
      * eligible for raffling.
      */
-    private function userAlreadyWonOrIsNoShow(JoindInUser $user): bool
+    private function userIsEligibleForRaffle(JoindInUser $user): bool
     {
-        if (in_array($user->getId(), [18486, 31686])) {
-            return true;
+        if ($user->isOrganizer()) {
+            return false;
         }
         foreach ($this->winners as $winner) {
             if ($winner === $user) {
-                return true;
+                return false;
             }
         }
 
         foreach ($this->noShows as $noShow) {
             if ($noShow === $user) {
-                return true;
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 }

--- a/src/Migrations/Version20171113151536.php
+++ b/src/Migrations/Version20171113151536.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171113151536 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE joindinusers ADD organizer BOOLEAN NOT NULL DEFAULT \'false\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE joindinUsers DROP organizer');
+    }
+}

--- a/src/Migrations/Version20171114112949.php
+++ b/src/Migrations/Version20171114112949.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * This migration will insert two records into joindinUsers, representing (up until the time of this migration) the two
+ * organizers of ZgPhp Meetup.
+ */
+class Version20171114112949 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration promotes two records as ZgPhp Meetup organizers
+        $this->addSql('UPDATE joindinUsers SET organizer = TRUE WHERE id IN (18486, 31686)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration demotes two records representing ZgPhp Meetup organizers
+        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(),
+            'Migration can only be executed safely on \'postgresql\'.');
+        $this->addSql('UPDATE joindinUsers SET organizer = FALSE WHERE id IN (18486, 31686)');
+    }
+}

--- a/tests/Entity/JoindInUserTest.php
+++ b/tests/Entity/JoindInUserTest.php
@@ -21,13 +21,16 @@ class JoindInUserTest extends TestCase
     private $displayName;
     /** @var JoindInUser */
     private $joindInUser;
+    /** @var bool */
+    private $organizer;
 
     public function setUp()
     {
         $this->id          = 1;
         $this->username    = 'username';
         $this->displayName = 'displayName';
-        $this->joindInUser = new JoindInUser($this->id, $this->username, $this->displayName);
+        $this->organizer   = false;
+        $this->joindInUser = new JoindInUser($this->id, $this->username, $this->displayName, $this->organizer);
     }
 
     public function testSetUsername()
@@ -38,6 +41,17 @@ class JoindInUserTest extends TestCase
     public function testSetDisplayName()
     {
         $this->markTestSkipped('Skipping');
+    }
+
+    public function testPromoteToOrganizer()
+    {
+        $this->joindInUser->promoteToOrganizer();
+        self::assertEquals(true, $this->joindInUser->isOrganizer());
+    }
+
+    public function testIsOrganizer()
+    {
+        self::assertEquals($this->organizer, $this->joindInUser->isOrganizer());
     }
 
     public function testGetId()


### PR DESCRIPTION
Organizer's comments should not be considered eligible to win prizes.

Added a new property to JoindInUser entity, generated migration files to reflect the changes in db table structure, and saved known organizers in db.

Raffling logic got refactored to deal with organizers' comments in a proper way.
 
Closes #78 

