### PR TITLE
Move symfony/dotenv back to dev requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "guzzlehttp/guzzle": "^6.3",
         "ramsey/uuid-doctrine": "^1.4",
         "symfony/console": "^3.4",
-        "symfony/dotenv": "^3.4",
         "symfony/expression-language": "^3.4",
         "symfony/flex": "^1.0",
         "symfony/framework-bundle": "^3.4",
@@ -32,7 +31,8 @@
         "phpspec/phpspec": "^4.2",
         "phpstan/phpstan": "^0.8.5",
         "phpunit/phpunit": "^6.4",
-        "squizlabs/php_codesniffer": "^3.1"
+        "squizlabs/php_codesniffer": "^3.1",
+        "symfony/dotenv": "^3.4"
     },
     "config": {
         "preferred-install": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd5b37d4bf4952cf5f8cbc8f450d5929",
+    "content-hash": "ebbd6bcdc1cc05ba565986643fa4d69b",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -2267,63 +2267,6 @@
             "description": "Symfony Doctrine Bridge",
             "homepage": "https://symfony.com",
             "time": "2017-11-07T14:20:24+00:00"
-        },
-        {
-            "name": "symfony/dotenv",
-            "version": "v3.4.0-BETA4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/dotenv.git",
-                "reference": "94d0115d249d598b1c2b246c53b83564fb39d678"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/94d0115d249d598b1c2b246c53b83564fb39d678",
-                "reference": "94d0115d249d598b1c2b246c53b83564fb39d678",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "require-dev": {
-                "symfony/process": "~3.2|~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Dotenv\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Registers environment variables from a .env file",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "dotenv",
-                "env",
-                "environment"
-            ],
-            "time": "2017-09-06T19:03:12+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -6967,6 +6910,63 @@
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
             "time": "2017-11-05T16:10:10+00:00"
+        },
+        {
+            "name": "symfony/dotenv",
+            "version": "v3.4.0-BETA4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dotenv.git",
+                "reference": "94d0115d249d598b1c2b246c53b83564fb39d678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/94d0115d249d598b1c2b246c53b83564fb39d678",
+                "reference": "94d0115d249d598b1c2b246c53b83564fb39d678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "require-dev": {
+                "symfony/process": "~3.2|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Dotenv\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Registers environment variables from a .env file",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "time": "2017-09-06T19:03:12+00:00"
         },
         {
             "name": "symfony/options-resolver",


### PR DESCRIPTION
Due to Heroku issues, dotenv was moved to regular requirements, we can move them back now

Closes #26