### PR TITLE
Disable schema validation checks on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,10 +30,6 @@ jobs:
           command: ./vendor/bin/phing refresh-test-db
 
       - run:
-          name: Validate database schema
-          command: ./vendor/bin/phing check-test-schema
-
-      - run:
           name: Lint all PHP code files
           command: find src/ -type f -name "*.php" -print0 | xargs -0 -n1 php -l
 


### PR DESCRIPTION
Disable schema validation checks on CircleCI

Backstory: Postgresql v10 changed way it handles sequences (autoincrements), but Doctrine still hasn't implemented the changes (Doctrine issue).

We are lucky enough to be able to generate and execute the migration files, but just can't validate schema state afterwards.

In order for our builds to pass on CircleCI
We need to temporarily disable schema validation checks (until Doctrine implements a fix.
 
Closes #144 

