### PR TITLE
#146: Write missing behat tests for implementing fos:user functionality

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -24,9 +24,19 @@ default:
                     kernel: '@kernel'
             filters:
                 tags: "@fetch && @api"
+        FOS_web:
+            contexts:
+                - FOSWebContext:
+                    kernel: '@kernel'
+            filters:
+                tags: "@web && @login"
 
     extensions:
         Behat\Symfony2Extension:
             kernel:
                 bootstrap: features/bootstrap/bootstrap.php
                 class: App\Kernel
+        Behat\MinkExtension:
+            sessions:
+                default:
+                    symfony2: ~

--- a/features/bootstrap/FOSWebContext.php
+++ b/features/bootstrap/FOSWebContext.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\Behat\Context\Context;
+use Behat\MinkExtension\Context\MinkContext;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class FOSWebContext extends MinkContext implements Context
+{
+    /** @var KernelInterface */
+    private $kernel;
+
+    public function __construct(KernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    protected function getService(string $name)
+    {
+        return $this->kernel->getContainer()->get($name);
+    }
+}

--- a/features/bootstrap/FOSWebContext.php
+++ b/features/bootstrap/FOSWebContext.php
@@ -16,6 +16,26 @@ class FOSWebContext extends MinkContext implements Context
         $this->kernel = $kernel;
     }
 
+    /**
+     * @When I visit :url
+     */
+    public function iVisit(string $url)
+    {
+        $this->visit($url);
+    }
+
+    /**
+     * @Given there is no user with username :username
+     */
+    public function thereIsNoUserWithUsername($username)
+    {
+        $userManager = $this->getService('fos_user.user_manager');
+        $user        = $userManager->findUserByUsername($username);
+        if (null !== $user) {
+            $userManager->deleteUser($user);
+        }
+    }
+
     protected function getService(string $name)
     {
         return $this->kernel->getContainer()->get($name);

--- a/features/fos_user/0-register-web.feature
+++ b/features/fos_user/0-register-web.feature
@@ -1,0 +1,17 @@
+@web @login
+Feature: Register new administrator
+  In order to be able to handle administrative tasks
+  As the system administrator
+  I need to be able to register with the site
+
+  Scenario: As an ordinary visitor, I should be able to register with the site
+    Given there is no user with username "admin.primus"
+    And I am on "/register/"
+    When I fill in "fos_user_registration_form[email]" with "admin@prim.us"
+    And I fill in "fos_user_registration_form[username]" with "admin.primus"
+    And I fill in "fos_user_registration_form[plainPassword][first]" with "12345"
+    And I fill in "fos_user_registration_form[plainPassword][second]" with "12345"
+    And I press "Register"
+    Then I should be on "/register/confirmed"
+    And I should see text matching "Logged in as admin.primus"
+    And I should see text matching "Congrats admin.primus, your account is now activated."

--- a/features/fos_user/1-login-web.feature
+++ b/features/fos_user/1-login-web.feature
@@ -1,0 +1,15 @@
+@web @login
+Feature: Show registered user their profile page
+  In order to see my profile page
+  As a registered user
+  I need to log in first
+
+  Scenario: As a registered user, I need to log in to see my profile page
+    Given I am on "/login"
+    And I fill in "_username" with "admin.primus"
+    And I fill in "_password" with "12345"
+    And I press "Log in"
+    Then I should be on "/"
+    And I visit "/profile"
+    And I should see text matching "Logged in as admin.primus"
+    And I should see text matching "Username: admin.primus"

--- a/features/fos_user/2-logout-web.feature
+++ b/features/fos_user/2-logout-web.feature
@@ -1,0 +1,23 @@
+@web @login
+Feature: Log out a logged in user
+  In order to be able to log out
+  As a regular user
+  I need to be logged in
+
+  Scenario: As a logged in user, I need to be able to log out
+#    log in
+    Given I am on "/login"
+    And I fill in "_username" with "admin.primus"
+    And I fill in "_password" with "12345"
+    And I press "Log in"
+    Then I should be on "/"
+#    confirm login
+    And I visit "/profile"
+    And I should see text matching "Logged in as admin.primus"
+    And I should see text matching "Username: admin.primus"
+#    log out
+    And I visit "/logout"
+    Then I should be on "/"
+#    confirm logout
+    And I visit "/profile"
+    Then I should be on "/login"


### PR DESCRIPTION
Wrote basic behat tests for fos:user:
covered registration, login, visit profile page, logout

Added setup for browser based behat tests (MinkExtension) and missing steps for Web context.

Closes #146 