### PR TITLE
Add http response codes to match domain exceptions

### DIFF
--- a/features/bootstrap/RaffleApiContext.php
+++ b/features/bootstrap/RaffleApiContext.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Entity\JoindInUser;
 use Behat\Behat\Context\Context;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Webmozart\Assert\Assert;
 
@@ -221,7 +222,7 @@ class RaffleApiContext implements Context
      */
     public function weGetAnExceptionForARaffleWithNoComments()
     {
-        Assert::contains($this->raffleId, 'There are no comments to raffle (RaffleID:');
+        Assert::eq($this->raffleId, '');
     }
 
     private function apiGetJson(string $url)
@@ -233,9 +234,13 @@ class RaffleApiContext implements Context
 
     private function apiPostJson(string $url, array $options = [])
     {
-        $response = $this->getGuzzle()->post($this->testApiUrl.$url, $options);
+        try {
+            $response = $this->getGuzzle()->post($this->testApiUrl.$url, $options);
 
-        return json_decode($response->getBody()->getContents(), true);
+            return json_decode($response->getBody()->getContents(), true);
+        } catch (ClientException $ex) {
+            return $ex->getMessage();
+        }
     }
 
     private function getGuzzle(): Client

--- a/src/Controller/RaffleApiController.php
+++ b/src/Controller/RaffleApiController.php
@@ -65,11 +65,11 @@ class RaffleApiController
 
             return new JsonResponse($raffle->getId());
         } catch (NoEventsToRaffleException $ex) {
-            return new JsonResponse($ex->getMessage());
+            return new JsonResponse($ex->getMessage(), 400);
         } catch (NoCommentsToRaffleException $ex) {
-            return new JsonResponse($ex->getMessage());
+            return new JsonResponse($ex->getMessage(), 204);
         } catch (\Exception $ex) {
-            return new JsonResponse('Something went wrong. Please hang up and try again.');
+            return new JsonResponse('Something went wrong. Please hang up and try again.', 400);
         }
     }
 


### PR DESCRIPTION
Situations such as trying to start a raffle without selecting any
events to raffle raise Domain Exceptions, but this should also be
reflected in invalid request responses.

This commit will add test scenario for starting a raffle with no
selected events, and confirm an http error 400 will be returned.

See issue #151, and [raffler frontend issue #7](https://github.com/zgphp/joindin-raffler-frontend/issues/7)


