### PR TITLE
Expose raffle's non eligible comments when raffle is serialized

### DIFF
--- a/src/Entity/Raffle.php
+++ b/src/Entity/Raffle.php
@@ -159,22 +159,28 @@ class Raffle implements \JsonSerializable
 
     public function jsonSerialize(): array
     {
-        $events  = [];
-        $comments=[];
+        $events             = [];
+        $eligibleComments   =[];
+        $noneligibleComments=[];
 
         foreach ($this->events as $event) {
             $events[] = $event->jsonSerialize();
         }
 
         foreach ($this->getCommentsEligibleForRaffling() as $comment) {
-            $comments[] = $comment->jsonSerialize();
+            $eligibleComments[] = $comment->jsonSerialize();
+        }
+
+        foreach ($this->getCommentsNotEligibleForRaffling() as $comment) {
+            $noneligibleComments[] = $comment->jsonSerialize();
         }
 
         return [
-            'id'                          => $this->id,
-            'createdAt'                   => $this->createdAt->format('c'),
-            'events'                      => $events,
-            'commentsEligibleForRaffling' => $comments,
+            'id'                             => $this->id,
+            'createdAt'                      => $this->createdAt->format('c'),
+            'events'                         => $events,
+            'commentsEligibleForRaffling'    => $eligibleComments,
+            'commentsNotEligibleForRaffling' => $noneligibleComments,
         ];
     }
 


### PR DESCRIPTION
In reference to issue #127 and PR #138, serialized raffle representation now holds comments not eligible for raffling, so as to clearly display  distinction between organizer's comments and regular member's ones front-end.

~~NOTE: needs to be rebased with master after #152 is merged!~~
_actually, it doesn't 🙂 need to work on my git skills a bit more..._