### PR TITLE
WIP #151 - Add proper tests for http response codes

### DIFF
--- a/features/bootstrap/RaffleContext.php
+++ b/features/bootstrap/RaffleContext.php
@@ -241,6 +241,22 @@ class RaffleContext implements Context
     }
 
     /**
+     * @Then /^we get an http response with status code (\d+)$/
+     */
+    public function weGetAnHttpResponseWithCode(int $statusCode)
+    {
+//        $options = [
+//            'json' => ['events' => []],
+//        ];
+//
+//        $this->apiPostJson('/raffle/start', $options);
+//
+//        Assert::eq($this->responseCode, $statusCode);
+
+        $this->weGetAnExceptionForARaffleWithNoMeetups();
+    }
+
+    /**
      * @Then we get an exception for a raffle with no comments
      */
     public function weGetAnExceptionForARaffleWithNoComments()

--- a/features/raffle/picking-events-to-raffle.feature
+++ b/features/raffle/picking-events-to-raffle.feature
@@ -36,7 +36,7 @@ Feature:
     Then there should be 2 events on the raffle
 
   Scenario: Organizer will try to start a raffle with no events
-    Then we get an exception for a raffle with no meetups
+    Then we get an http response with status code 400
 
   Scenario: Organizer will try to start a raffle with events not having any comments
     Given we have these uncommented meetups in the system


### PR DESCRIPTION
When making an API call without needed parameters
Backend will raise a DomainException
And HTTP response should have a corresponding response code

This will add behat tests for NoEventsToRaffleException which should cause HTTP 400 response

Closes #151 

