### PR TITLE
#156 - Add single controller endpoint to run all JoindIn data imports

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -2,6 +2,10 @@ homepage:
     path: /
     defaults: { _controller: 'App\Controller\HomepageController::index' }
 
+joindin_fetch_all:
+    path: /api/joindin/fetch/all
+    defaults: { _controller: 'App\Controller\HomepageController::fetchJoindInData' }
+
 joindin_events_fetch:
     path: /api/joindin/events/fetch
     defaults: { _controller: 'App\Controller\JoindInEventController::fetch' }

--- a/features/bootstrap/JoindInApiContext.php
+++ b/features/bootstrap/JoindInApiContext.php
@@ -50,6 +50,14 @@ class JoindInApiContext implements Context
     }
 
     /**
+     * @When I fetch all meetups with talks and their comments from Joindin in one go
+     */
+    public function iFetchAllMeetupsWithTalksAndTheirCommentsFromJoindIn()
+    {
+        $this->apiGetJson('/joindin/fetch/all');
+    }
+
+    /**
      * @Then there should be :count ZgPHP meetups in system
      */
     public function thereShouldBeZgphpMeetupsInSystem(int $count)

--- a/features/bootstrap/JoindInContext.php
+++ b/features/bootstrap/JoindInContext.php
@@ -84,4 +84,14 @@ class JoindInContext implements Context
     {
         return $this->kernel->getContainer()->get($name);
     }
+
+    /**
+     * @When I fetch all meetups with talks and their comments from Joindin in one go
+     */
+    public function iFetchAllMeetupsWithTalksAndTheirCommentsFromJoindIn()
+    {
+        $this->iFetchMeetupDataFromJoindIn();
+        $this->iFetchMeetupTalksFromJoindIn();
+        $this->iFetchMeetupTalkCommentsFromJoindIn();
+    }
 }

--- a/features/fetching-joind-in-data.feature
+++ b/features/fetching-joind-in-data.feature
@@ -28,3 +28,9 @@ Feature:
       | 22817 | Fullstacking - 101 | 6674    |
     When I fetch meetup talk comments from Joind.in
     Then there should be 3 comment in system
+
+  Scenario: It fetches all ZGPHP data from Joind.in in one go
+    When I fetch all meetups with talks and their comments from Joindin in one go
+    Then there should be 27 ZgPHP meetups in system
+    Then there should be 49 talks in system
+    Then there should be 193 comment in system

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -4,12 +4,69 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Repository\JoindInEventRepository;
+use App\Repository\JoindInTalkRepository;
+use App\Service\JoindInCommentRetrieval;
+use App\Service\JoindInEventRetrieval;
+use App\Service\JoindInTalkRetrieval;
 use Symfony\Component\HttpFoundation\Response;
 
 class HomepageController
 {
+    /**
+     * @var \App\Service\JoindInEventRetrieval
+     */
+    private $joindInEventRetrieval;
+    /**
+     * @var \App\Repository\JoindInEventRepository
+     */
+    private $eventRepository;
+    /**
+     * @var \App\Service\JoindInTalkRetrieval
+     */
+    private $joindInTalkRetrieval;
+    /**
+     * @var \App\Repository\JoindInTalkRepository
+     */
+    private $talkRepository;
+    /**
+     * @var \App\Service\JoindInCommentRetrieval
+     */
+    private $joindInCommentRetrieval;
+
+    public function __construct(
+        JoindInEventRetrieval $joindInEventRetrieval,
+        JoindInEventRepository $eventRepository,
+        JoindInTalkRetrieval $joindInTalkRetrieval,
+        JoindInTalkRepository $talkRepository,
+        JoindInCommentRetrieval $joindInCommentRetrieval
+    ) {
+        $this->joindInEventRetrieval   = $joindInEventRetrieval;
+        $this->eventRepository         = $eventRepository;
+        $this->joindInTalkRetrieval    = $joindInTalkRetrieval;
+        $this->talkRepository          = $talkRepository;
+        $this->joindInCommentRetrieval = $joindInCommentRetrieval;
+    }
+
     public function index(): Response
     {
         return new Response('OK');
+    }
+
+    public function fetchJoindInData()
+    {
+        try {
+            $this->joindInEventRetrieval->fetch();
+            foreach ($this->eventRepository->findAll() as $event) {
+                $this->joindInTalkRetrieval->fetch($event);
+            }
+            foreach ($this->talkRepository->findAll() as $talk) {
+                $this->joindInCommentRetrieval->fetch($talk);
+            }
+
+            return new Response('OK');
+        } catch (\Exception $ex) {
+            return new Response($ex->getMessage(), $ex->getCode());
+        }
     }
 }


### PR DESCRIPTION
Create a new, single JoindIn data import endpoint

In order to save time when preparing data for a new raffle, reduce the number of manual actions needed to be performed by admin, and thus reducing the risk of running them in the wrong order
For admin preparing data for a new raffle
We will add a single endpoint that will perform all data imports from JoindIn automatically
Whereas currently we need to manually import all the data in discrete steps (event>talks>comments)

Closes #156 

NOTES (@msvrtan):

- would appreciate your advice on the way `@fetch` context's step for this endpoint is implemented. It feels kind of hacky to me; because I'm not sure we need to create a new service out of this new controller's method, I've just invoked other discrete steps to get the same functionality.
- in reference to #163 - until that's implemented, I'm keeping this route in the open
- after #163 is closed and this route gets protected, we'll add it to admin panel as admin action

