### PR TITLE
#136 - Disable registration (Christmas bonus specials: ✓#168 && 𐄂 #169)

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -34,6 +34,6 @@ security:
 
     access_control:
         - { path: ^/login$, role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/register, role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/register, role: ROLE_ADMIN }
         - { path: ^/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/admin/, role: ROLE_ADMIN }

--- a/features/bootstrap/FOSWebContext.php
+++ b/features/bootstrap/FOSWebContext.php
@@ -3,8 +3,13 @@
 declare(strict_types=1);
 
 use Behat\Behat\Context\Context;
+use Behat\Mink\Driver\BrowserKitDriver;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\MinkContext;
+use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class FOSWebContext extends MinkContext implements Context
 {
@@ -39,5 +44,68 @@ class FOSWebContext extends MinkContext implements Context
     protected function getService(string $name)
     {
         return $this->kernel->getContainer()->get($name);
+    }
+
+    /**
+     * @Given I am not logged in
+     */
+    public function iAmNotLoggedIn()
+    {
+        $driver = $this->getSession()->getDriver();
+        if (!$driver instanceof BrowserKitDriver) {
+            throw new UnsupportedDriverActionException('This step is only supported by the BrowserKitDriver', $driver);
+        }
+
+        /** @var \Symfony\Bundle\FrameworkBundle\Client $client */
+        $client = $driver->getClient();
+
+        $client->getCookieJar()->set(new Cookie(session_name(), 'anon_user_not_logged_in'));
+
+        /** @var Symfony\Component\HttpFoundation\Session\Session $session */
+        $session = $this->getService('session');
+
+        $providerKey = $this->kernel->getContainer()->getParameter('fos_user.firewall_name');
+
+        $token = new AnonymousToken('$3cr37', 'anon', []);
+        $session->set('_security_'.$providerKey, serialize($token));
+        $session->save();
+
+        $cookie = new Cookie($session->getName(), $session->getId());
+        $client->getCookieJar()->set($cookie);
+    }
+
+    /**
+     * @Given I am authorized with :accessRole
+     */
+    public function iAmAuthorizedWith($accessRole)
+    {
+        $driver = $this->getSession()->getDriver();
+        if (!$driver instanceof BrowserKitDriver) {
+            throw new UnsupportedDriverActionException('This step is only supported by the BrowserKitDriver', $driver);
+        }
+
+        /** @var \Symfony\Bundle\FrameworkBundle\Client $client */
+        $client = $driver->getClient();
+
+        /** @var Symfony\Component\HttpFoundation\Session\Session $session */
+        $session = $this->getService('session');
+
+//        clear residual session data from any previous scenarios
+        $session->clear();
+
+        $providerKey = $this->kernel->getContainer()->getParameter('fos_user.firewall_name');
+
+        /** @var \FOS\UserBundle\Doctrine\UserManager $fosUserManager */
+        $fosUserManager = $this->getService('fos_user.user_manager');
+
+        $user = $fosUserManager->findUserByUsername('admin');
+
+        $token = new UsernamePasswordToken($user, $user->getPassword(), $providerKey, [$accessRole]);
+
+        $session->set('_security_'.$providerKey, serialize($token));
+        $session->save();
+
+        $cookie = new Cookie($session->getName(), $session->getId());
+        $client->getCookieJar()->set($cookie);
     }
 }

--- a/features/fos_user/0-register-web.feature
+++ b/features/fos_user/0-register-web.feature
@@ -4,14 +4,12 @@ Feature: Register new administrator
   As the system administrator
   I need to be able to register with the site
 
-  Scenario: As an ordinary visitor, I should be able to register with the site
-    Given there is no user with username "admin.primus"
-    And I am on "/register/"
-    When I fill in "fos_user_registration_form[email]" with "admin@prim.us"
-    And I fill in "fos_user_registration_form[username]" with "admin.primus"
-    And I fill in "fos_user_registration_form[plainPassword][first]" with "12345"
-    And I fill in "fos_user_registration_form[plainPassword][second]" with "12345"
-    And I press "Register"
-    Then I should be on "/register/confirmed"
-    And I should see text matching "Logged in as admin.primus"
-    And I should see text matching "Congrats admin.primus, your account is now activated."
+  Scenario: As an ordinary visitor, I should not be able to access the registration page
+    Given I am not logged in
+    And I visit "/register/"
+    Then I should be on "/login"
+
+  Scenario: As a system administrator, I should be able to access the registration page
+    Given I am authorized with ROLE_ADMIN
+    And I visit "/register/"
+    Then I should be on "/register/"

--- a/features/fos_user/1-login-web.feature
+++ b/features/fos_user/1-login-web.feature
@@ -6,10 +6,10 @@ Feature: Show registered user their profile page
 
   Scenario: As a registered user, I need to log in to see my profile page
     Given I am on "/login"
-    And I fill in "_username" with "admin.primus"
-    And I fill in "_password" with "12345"
+    And I fill in "_username" with "admin"
+    And I fill in "_password" with "admin"
     And I press "Log in"
     Then I should be on "/"
     And I visit "/profile"
-    And I should see text matching "Logged in as admin.primus"
-    And I should see text matching "Username: admin.primus"
+    And I should see text matching "Logged in as admin"
+    And I should see text matching "Username: admin"

--- a/features/fos_user/2-logout-web.feature
+++ b/features/fos_user/2-logout-web.feature
@@ -7,14 +7,14 @@ Feature: Log out a logged in user
   Scenario: As a logged in user, I need to be able to log out
 #    log in
     Given I am on "/login"
-    And I fill in "_username" with "admin.primus"
-    And I fill in "_password" with "12345"
+    And I fill in "_username" with "admin"
+    And I fill in "_password" with "admin"
     And I press "Log in"
     Then I should be on "/"
 #    confirm login
     And I visit "/profile"
-    And I should see text matching "Logged in as admin.primus"
-    And I should see text matching "Username: admin.primus"
+    And I should see text matching "Logged in as admin"
+    And I should see text matching "Username: admin"
 #    log out
     And I visit "/logout"
     Then I should be on "/"


### PR DESCRIPTION
In order to prevent visitors from creating user accounts on website
And provide administrators with ability to create accounts for new administrators
As developers
We need to restrict the access to registration page only to administrators

This PR will allow access to registration page to administrators only, and will add behat scenarios and step implementations for this new rule.

Coincidentally, this also enables closing of #168, because restricting access to registration page caused the removal of tests for registration for new users, but created problems with new registration confirmation (see #169)

Closes #136 and #168 