### PR TITLE
#165 - Add JoindIn entities to admin supervision

### DIFF
--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -1,4 +1,8 @@
 easy_admin:
     entities:
         # List the entity class name you want to manage
+        - App\Entity\JoindInEvent
+        - App\Entity\JoindInTalk
+        - App\Entity\JoindInComment
+        - App\Entity\JoindInUser
         - App\Entity\Raffle


### PR DESCRIPTION
In order to better manipulate our entities
For application administrators
We will track business entities in administration backend
Whereas currently we have no control over creating new or editing existing events, talks, comments, users, or raffles

Closes #165 

