### PR TITLE
#164 - Admin - editing raffle doesn't work

### DIFF
--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -1,8 +1,21 @@
 easy_admin:
+    list:
+        actions: ['search', 'delete', 'show']
     entities:
-        # List the entity class name you want to manage
-        - App\Entity\JoindInEvent
-        - App\Entity\JoindInTalk
-        - App\Entity\JoindInComment
-        - App\Entity\JoindInUser
-        - App\Entity\Raffle
+        JoindInEvent:
+            class: App\Entity\JoindInEvent
+        JoindInTalk:
+            class: App\Entity\JoindInTalk
+        JoindInComment:
+            class: App\Entity\JoindInComment
+        JoindInUser:
+            class: App\Entity\JoindInUser
+        Raffle:
+            class: App\Entity\Raffle
+            disabled_actions: ['new']
+            edit:
+                fields:
+                    - events
+                    - winners
+                    - noShows
+

--- a/features/admin/easy-admin-access.feature
+++ b/features/admin/easy-admin-access.feature
@@ -1,0 +1,15 @@
+@web @login
+Feature: Prevent unauthorized access to admin backend
+  In order to protect admin backend from unauthorized access
+  As the system administrator
+  I need to restrict access to admin only to users authorized as administrators
+
+  Scenario: As an ordinary visitor, I should not be able to access the admin page
+    Given I am not logged in
+    And I visit "/admin/"
+    Then I should be on "/login"
+
+  Scenario: As a system administrator, I should be able to access the admin page
+    Given I am authorized with ROLE_ADMIN
+    And I visit "/admin/"
+    Then I should be on "/admin/"

--- a/features/fetching-joind-in-data.feature
+++ b/features/fetching-joind-in-data.feature
@@ -32,5 +32,5 @@ Feature:
   Scenario: It fetches all ZGPHP data from Joind.in in one go
     When I fetch all meetups with talks and their comments from Joindin in one go
     Then there should be 27 ZgPHP meetups in system
-    Then there should be 49 talks in system
-    Then there should be 197 comment in system
+    Then there should be 51 talks in system
+    Then there should be 199 comment in system

--- a/src/Entity/Raffle.php
+++ b/src/Entity/Raffle.php
@@ -226,4 +226,14 @@ class Raffle implements \JsonSerializable
 
         return $comments;
     }
+
+    public function getWinners()
+    {
+        return $this->winners;
+    }
+
+    public function getNoShows()
+    {
+        return $this->noShows;
+    }
 }


### PR DESCRIPTION
This is rebased with #171 (adding JoindIn entities to be handled with easyadmin).

I've added some missing __toString() methods so that the display of `edit` forms works.
But the editing itself is broken, because not all properties have setter methods.

The last commit adds some configuration to easyadmin's .yaml config, which enables defining which properties in which entities should be editable (see new comments in issue #164)