### PR TITLE
#163 -  Add security scenarios to admin

### DIFF
--- a/features/admin/easy-admin-access.feature
+++ b/features/admin/easy-admin-access.feature
@@ -1,0 +1,15 @@
+@web @login
+Feature: Prevent unauthorized access to admin backend
+  In order to protect admin backend from unauthorized access
+  As the system administrator
+  I need to restrict access to admin only to users authorized as administrators
+
+  Scenario: As an ordinary visitor, I should not be able to access the admin page
+    Given I am not logged in
+    And I visit "/admin/"
+    Then I should be on "/login"
+
+  Scenario: As a system administrator, I should be able to access the admin page
+    Given I am authorized with ROLE_ADMIN
+    And I visit "/admin/"
+    Then I should be on "/admin/"

--- a/features/fetching-joind-in-data.feature
+++ b/features/fetching-joind-in-data.feature
@@ -32,5 +32,5 @@ Feature:
   Scenario: It fetches all ZGPHP data from Joind.in in one go
     When I fetch all meetups with talks and their comments from Joindin in one go
     Then there should be 27 ZgPHP meetups in system
-    Then there should be 49 talks in system
-    Then there should be 197 comment in system
+    Then there should be 51 talks in system
+    Then there should be 199 comment in system


### PR DESCRIPTION
In order to prove administrator pages are protected from unauthorized access
For administrators
We will add Behat tests that try accessing the admin pages as authorized and unauthorized user
Whereas currently we didn't have any tests, and had to check manually

Closes #163 

(NOTE: rebased with #173 due to failing tests)