### PR TITLE
#175 - Disable 'New' and 'Edit' actions for JoindIn* enitites

### DIFF
--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -4,12 +4,16 @@ easy_admin:
     entities:
         JoindInEvent:
             class: App\Entity\JoindInEvent
+            disabled_actions: ['new', 'edit']
         JoindInTalk:
             class: App\Entity\JoindInTalk
+            disabled_actions: ['new', 'edit']
         JoindInComment:
             class: App\Entity\JoindInComment
+            disabled_actions: ['new', 'edit']
         JoindInUser:
             class: App\Entity\JoindInUser
+            disabled_actions: ['new', 'edit']
         Raffle:
             class: App\Entity\Raffle
             disabled_actions: ['new']

--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -18,4 +18,13 @@ easy_admin:
                     - events
                     - winners
                     - noShows
+        Administrators:
+            class: App\Entity\User
+            list:
+              fields:
+                - username
+                - email
+                - enabled
+                - { property: 'roles', type: 'array'}
+                - { property: 'administrator',  type: 'toggle' }
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -18,9 +18,27 @@ class User extends BaseUser
      */
     protected $id;
 
+    /**
+     * @var bool
+     *
+     * Flags this user as admin (adds ROLE_SUPER_ADMIN)
+     */
+    private $administrator;
+
     public function __construct()
     {
         parent::__construct();
         // your own logic
+    }
+
+    public function isAdministrator(): bool
+    {
+        return $this->isSuperAdmin();
+    }
+
+    public function setAdministrator($boolean)
+    {
+        $this->setSuperAdmin($boolean);
+        $this->administrator = $boolean;
     }
 }


### PR DESCRIPTION
In reference to #175 , JoindIn entities should not be editable nor should it be possible to create new instances using admin backend.

Closes #175  