### PR TITLE
#166 - Populate admin with users

### DIFF
--- a/config/packages/easy_admin.yaml
+++ b/config/packages/easy_admin.yaml
@@ -18,4 +18,13 @@ easy_admin:
                     - events
                     - winners
                     - noShows
+        Administrators:
+            class: App\Entity\User
+            list:
+              fields:
+                - username
+                - email
+                - enabled
+                - { property: 'roles', type: 'array'}
+                - { property: 'administrator',  type: 'toggle' }
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -18,9 +18,27 @@ class User extends BaseUser
      */
     protected $id;
 
+    /**
+     * @var bool
+     *
+     * Flags this user as admin (adds ROLE_SUPER_ADMIN)
+     */
+    private $administrator;
+
     public function __construct()
     {
         parent::__construct();
         // your own logic
+    }
+
+    public function isAdministrator(): bool
+    {
+        return $this->isSuperAdmin();
+    }
+
+    public function setAdministrator($boolean)
+    {
+        $this->setSuperAdmin($boolean);
+        $this->administrator = $boolean;
     }
 }


### PR DESCRIPTION
In order to ease the administration of users (promoting regular users to administrators)
For system administrators
We will enable user administration in the EasyAdmin backend
Whereas currently we are promoting users to administrators using command line
 
Closes #166 

