### PR TITLE
#182 - Mark new co-organizers as admins

### DIFF
--- a/src/Migrations/Version20180126123008.php
+++ b/src/Migrations/Version20180126123008.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180126123008 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration promotes four records as ZgPhp Meetup organizers
+        $this->addSql('UPDATE joindinUsers SET organizer = TRUE WHERE id IN (27939, 31316, 47268, 26764)');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration demotes four records representing ZgPhp Meetup organizers
+        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(),
+            'Migration can only be executed safely on \'postgresql\'.');
+        $this->addSql('UPDATE joindinUsers SET organizer = FALSE WHERE id IN (27939, 31316, 47268, 26764)');
+    }
+}


### PR DESCRIPTION
New co-organizers should be excluded from the raffle, so we need to mark
them as admin in the list of users.

Closes #182

