### PR TITLE
#184 - Fix Joind.In sync crash

### DIFF
--- a/features/fetching-joind-in-data.feature
+++ b/features/fetching-joind-in-data.feature
@@ -10,7 +10,7 @@ Feature:
 
   Scenario: It fetches meetups from Joind.in
     When I fetch meetup data from Joind.in
-    Then there should be 27 ZgPHP meetups in system
+    Then there should be 28 ZgPHP meetups in system
 
   Scenario: It fetches talks from Joind.in meetups we have in our system
     Given we have these meetups in the system
@@ -31,6 +31,6 @@ Feature:
 
   Scenario: It fetches all ZGPHP data from Joind.in in one go
     When I fetch all meetups with talks and their comments from Joindin in one go
-    Then there should be 27 ZgPHP meetups in system
-    Then there should be 51 talks in system
-    Then there should be 199 comment in system
+    Then there should be 28 ZgPHP meetups in system
+    Then there should be 59 talks in system
+    Then there should be 237 comment in system

--- a/src/JoindIn/CommentDataFactory.php
+++ b/src/JoindIn/CommentDataFactory.php
@@ -17,8 +17,8 @@ class CommentDataFactory
             (int) $input['rating'],
             new UserData(
                 $this->extractUserIdFromUri($input['user_uri']),
-                $input['username'],
-                $input['user_display_name']
+                (string) $input['username'],
+                (string) $input['user_display_name']
             ),
             $talk
         );


### PR DESCRIPTION
Joind.in sync crashed when trying to pull in data.

One of our users decided to use a floating point number as their username.
Although when transferred over HTTP the integer was converted to string, PHP 7's strict type declaration caused it to be converted back to integer on our side.

Since we were naively expecting all such data (attributes related to joind.id user data) to be strings, this caused a bug in CommentDataFactory.

Explicitly typecasting these attributes to strings fixes the bug.
Until it pops up somewhere else.
Should test for same issue with other comment fields.

Closes #184 