### PR TITLE
Define return types where missing

### DIFF
--- a/features/bootstrap/FOSWebContext.php
+++ b/features/bootstrap/FOSWebContext.php
@@ -24,7 +24,7 @@ class FOSWebContext extends MinkContext implements Context
     /**
      * @When I visit :url
      */
-    public function iVisit(string $url)
+    public function iVisit(string $url): void
     {
         $this->visit($url);
     }
@@ -32,7 +32,7 @@ class FOSWebContext extends MinkContext implements Context
     /**
      * @Given there is no user with username :username
      */
-    public function thereIsNoUserWithUsername($username)
+    public function thereIsNoUserWithUsername(string $username): void
     {
         $userManager = $this->getService('fos_user.user_manager');
         $user        = $userManager->findUserByUsername($username);
@@ -41,6 +41,9 @@ class FOSWebContext extends MinkContext implements Context
         }
     }
 
+    /**
+     * @return object
+     */
     protected function getService(string $name)
     {
         return $this->kernel->getContainer()->get($name);
@@ -49,7 +52,7 @@ class FOSWebContext extends MinkContext implements Context
     /**
      * @Given I am not logged in
      */
-    public function iAmNotLoggedIn()
+    public function iAmNotLoggedIn(): void
     {
         $driver = $this->getSession()->getDriver();
         if (!$driver instanceof BrowserKitDriver) {
@@ -77,7 +80,7 @@ class FOSWebContext extends MinkContext implements Context
     /**
      * @Given I am authorized with :accessRole
      */
-    public function iAmAuthorizedWith($accessRole)
+    public function iAmAuthorizedWith(string $accessRole): void
     {
         $driver = $this->getSession()->getDriver();
         if (!$driver instanceof BrowserKitDriver) {

--- a/features/bootstrap/HelperTrait.php
+++ b/features/bootstrap/HelperTrait.php
@@ -17,7 +17,7 @@ trait HelperTrait
     /**
      * @BeforeScenario
      */
-    public function cleanDB(BeforeScenarioScope $scope)
+    public function cleanDB(BeforeScenarioScope $scope): void
     {
         // Remove all meetups, talks & comments.
         foreach ($this->getEventRepository()->findAll() as $joindInEvent) {
@@ -42,7 +42,13 @@ trait HelperTrait
      */
     public function castToUser(string $username): JoindInUser
     {
-        return $this->getUserRepository()->findOneByUsername($username);
+        $user = $this->getUserRepository()->findOneByUsername($username);
+
+        if (null === $user) {
+            throw new \RuntimeException('Cant find user with username: '.$username);
+        }
+
+        return $user;
     }
 
     protected function loadMultipleUsers(string $userNames): array

--- a/features/bootstrap/JoindInApiContext.php
+++ b/features/bootstrap/JoindInApiContext.php
@@ -28,7 +28,7 @@ class JoindInApiContext implements Context
     /**
      * @When I fetch meetup data from Joind.in
      */
-    public function iFetchMeetupDataFromJoindIn()
+    public function iFetchMeetupDataFromJoindIn(): void
     {
         $this->apiGetJson('/joindin/events/fetch');
     }
@@ -36,7 +36,7 @@ class JoindInApiContext implements Context
     /**
      * @When I fetch meetup talks from Joind.in
      */
-    public function iFetchMeetupTalksFromJoindIn()
+    public function iFetchMeetupTalksFromJoindIn(): void
     {
         $this->apiGetJson('/joindin/talks/fetch');
     }
@@ -44,7 +44,7 @@ class JoindInApiContext implements Context
     /**
      * @When I fetch meetup talk comments from Joind.in
      */
-    public function iFetchMeetupTalkCommentsFromJoindIn()
+    public function iFetchMeetupTalkCommentsFromJoindIn(): void
     {
         $this->apiGetJson('/joindin/comments/fetch');
     }
@@ -52,7 +52,7 @@ class JoindInApiContext implements Context
     /**
      * @When I fetch all meetups with talks and their comments from Joindin in one go
      */
-    public function iFetchAllMeetupsWithTalksAndTheirCommentsFromJoindIn()
+    public function iFetchAllMeetupsWithTalksAndTheirCommentsFromJoindIn(): void
     {
         $this->apiGetJson('/joindin/fetch/all');
     }
@@ -60,7 +60,7 @@ class JoindInApiContext implements Context
     /**
      * @Then there should be :count ZgPHP meetups in system
      */
-    public function thereShouldBeZgphpMeetupsInSystem(int $count)
+    public function thereShouldBeZgphpMeetupsInSystem(int $count): void
     {
         Assert::count($this->apiGetJson('/joindin/events/'), $count);
     }
@@ -68,7 +68,7 @@ class JoindInApiContext implements Context
     /**
      * @Then there should be :count talks in system
      */
-    public function thereShouldBeTalksInSystem(int $count)
+    public function thereShouldBeTalksInSystem(int $count): void
     {
         Assert::count($this->apiGetJson('/joindin/talks/'), $count);
     }
@@ -76,21 +76,26 @@ class JoindInApiContext implements Context
     /**
      * @Then there should be :count comment in system
      */
-    public function thereShouldBeCommentInSystem(int $count)
+    public function thereShouldBeCommentInSystem(int $count): void
     {
         $data = $this->apiGetJson('/joindin/comments/');
 
         Assert::count($data, $count);
     }
 
+    /** @return mixed */
     private function apiGetJson(string $url)
     {
+        /** @var Client $guzzle */
         $guzzle   = $this->getService(Client::class);
         $response = $guzzle->get($this->testApiUrl.$url);
 
         return json_decode($response->getBody()->getContents(), true);
     }
 
+    /**
+     * @return object
+     */
     protected function getService(string $name)
     {
         return $this->kernel->getContainer()->get($name);

--- a/features/bootstrap/JoindInContext.php
+++ b/features/bootstrap/JoindInContext.php
@@ -25,8 +25,9 @@ class JoindInContext implements Context
     /**
      * @When I fetch meetup data from Joind.in
      */
-    public function iFetchMeetupDataFromJoindIn()
+    public function iFetchMeetupDataFromJoindIn(): void
     {
+        /** @var JoindInEventRetrieval $service */
         $service = $this->getService(JoindInEventRetrieval::class);
 
         $service->fetch();
@@ -35,8 +36,9 @@ class JoindInContext implements Context
     /**
      * @When I fetch meetup talks from Joind.in
      */
-    public function iFetchMeetupTalksFromJoindIn()
+    public function iFetchMeetupTalksFromJoindIn(): void
     {
+        /** @var JoindInTalkRetrieval $service */
         $service = $this->getService(JoindInTalkRetrieval::class);
 
         foreach ($this->getEventRepository()->findAll() as $event) {
@@ -47,8 +49,9 @@ class JoindInContext implements Context
     /**
      * @When I fetch meetup talk comments from Joind.in
      */
-    public function iFetchMeetupTalkCommentsFromJoindIn()
+    public function iFetchMeetupTalkCommentsFromJoindIn(): void
     {
+        /** @var JoindInCommentRetrieval $service */
         $service = $this->getService(JoindInCommentRetrieval::class);
 
         foreach ($this->getTalkRepository()->findAll() as $talk) {
@@ -59,7 +62,7 @@ class JoindInContext implements Context
     /**
      * @Then there should be :count ZgPHP meetups in system
      */
-    public function thereShouldBeZgphpMeetupsInSystem(int $count)
+    public function thereShouldBeZgphpMeetupsInSystem(int $count): void
     {
         Assert::count($this->getEventRepository()->findAll(), $count);
     }
@@ -67,7 +70,7 @@ class JoindInContext implements Context
     /**
      * @Then there should be :count talks in system
      */
-    public function thereShouldBeTalksInSystem(int $count)
+    public function thereShouldBeTalksInSystem(int $count): void
     {
         Assert::count($this->getTalkRepository()->findAll(), $count);
     }
@@ -75,11 +78,14 @@ class JoindInContext implements Context
     /**
      * @Then there should be :count comment in system
      */
-    public function thereShouldBeCommentInSystem(int $count)
+    public function thereShouldBeCommentInSystem(int $count): void
     {
         Assert::count($this->getCommentRepository()->findAll(), $count);
     }
 
+    /**
+     * @return object
+     */
     protected function getService(string $name)
     {
         return $this->kernel->getContainer()->get($name);
@@ -88,7 +94,7 @@ class JoindInContext implements Context
     /**
      * @When I fetch all meetups with talks and their comments from Joindin in one go
      */
-    public function iFetchAllMeetupsWithTalksAndTheirCommentsFromJoindIn()
+    public function iFetchAllMeetupsWithTalksAndTheirCommentsFromJoindIn(): void
     {
         $this->iFetchMeetupDataFromJoindIn();
         $this->iFetchMeetupTalksFromJoindIn();

--- a/features/bootstrap/JoindInFixturesTrait.php
+++ b/features/bootstrap/JoindInFixturesTrait.php
@@ -14,7 +14,7 @@ trait JoindInFixturesTrait
      * @Given we have these uncommented meetups in the system
      * @Given we have these meetups in the system
      */
-    public function weHaveTheseMeetupsInTheSystem(TableNode $table)
+    public function weHaveTheseMeetupsInTheSystem(TableNode $table): void
     {
         foreach ($table as $row) {
             $date  = new DateTime($row['date']);
@@ -28,7 +28,7 @@ trait JoindInFixturesTrait
     /**
      * @Given we have these talks in the system
      */
-    public function weHaveTheseTalksInTheSystem(TableNode $table)
+    public function weHaveTheseTalksInTheSystem(TableNode $table): void
     {
         foreach ($table as $row) {
             $event = $this->getEventRepository()->find($row['eventId']);
@@ -44,7 +44,7 @@ trait JoindInFixturesTrait
     /**
      * @Given we have these users in the system
      */
-    public function weHaveTheseUsersInTheSystem(TableNode $table)
+    public function weHaveTheseUsersInTheSystem(TableNode $table): void
     {
         foreach ($table as $row) {
             $isOrganizer = 'true' === $row['organizer'] ? true : false;
@@ -58,7 +58,7 @@ trait JoindInFixturesTrait
     /**
      * @Given we have each user commenting on each talk
      */
-    public function weHaveEachUserCommentingOnEachTalk()
+    public function weHaveEachUserCommentingOnEachTalk(): void
     {
         $users = $this->getUserRepository()->findAll();
         $talks = $this->getTalkRepository()->findAll();

--- a/features/bootstrap/RaffleApiContext.php
+++ b/features/bootstrap/RaffleApiContext.php
@@ -34,7 +34,7 @@ class RaffleApiContext implements Context
     /**
      * @When organizer picks to raffle meetups: :eventIdList
      */
-    public function organizerPicksToRaffleMeetups(string $eventIdList)
+    public function organizerPicksToRaffleMeetups(string $eventIdList): void
     {
         $options = [
             'json' => ['events' => explode(',', $eventIdList)],
@@ -47,7 +47,7 @@ class RaffleApiContext implements Context
     /**
      * @Then we get an exception for a raffle with no meetups
      */
-    public function weGetAnExceptionForARaffleWithNoMeetups()
+    public function weGetAnExceptionForARaffleWithNoMeetups(): void
     {
         $options = [
             'json' => ['events' => []],
@@ -62,7 +62,7 @@ class RaffleApiContext implements Context
      * @When I pick a winner
      * @When I pick another winner
      */
-    public function wePick()
+    public function wePick(): void
     {
         $this->picked = $this->apiPostJson('/raffle/'.$this->raffleId.'/pick');
     }
@@ -70,7 +70,7 @@ class RaffleApiContext implements Context
     /**
      * @When I confirm him or her as a winner
      */
-    public function iConfirmHimOrHerAsAWinner()
+    public function iConfirmHimOrHerAsAWinner(): void
     {
         $url = '/raffle/'.$this->raffleId.'/winner/'.$this->picked['id'];
 
@@ -80,7 +80,7 @@ class RaffleApiContext implements Context
     /**
      * @When I mark him or her as a no show
      */
-    public function iMarkHimOrHerAsANoShow()
+    public function iMarkHimOrHerAsANoShow(): void
     {
         $url = '/raffle/'.$this->raffleId.'/no_show/'.$this->picked['id'];
 
@@ -90,7 +90,7 @@ class RaffleApiContext implements Context
     /**
      * @When user :user wins
      */
-    public function userWins(JoindInUser $user)
+    public function userWins(JoindInUser $user): void
     {
         $url = '/raffle/'.$this->raffleId.'/winner/'.$user->getId();
 
@@ -100,7 +100,7 @@ class RaffleApiContext implements Context
     /**
      * @When user :user is no show
      */
-    public function userIsNoShow(JoindInUser $user)
+    public function userIsNoShow(JoindInUser $user): void
     {
         $url = '/raffle/'.$this->raffleId.'/no_show/'.$user->getId();
 
@@ -110,7 +110,7 @@ class RaffleApiContext implements Context
     /**
      * @Then there should be :count events on the raffle
      */
-    public function thereShouldBeEventsOnTheRaffle(int $count)
+    public function thereShouldBeEventsOnTheRaffle(int $count): void
     {
         $data = $this->apiGetJson('/raffle/'.$this->raffleId);
 
@@ -120,7 +120,7 @@ class RaffleApiContext implements Context
     /**
      * @Then there should be :count comments on the raffle
      */
-    public function thereShouldBeCommentsOnTheRaffle(int $count)
+    public function thereShouldBeCommentsOnTheRaffle(int $count): void
     {
         Assert::count($this->apiGetJson('/raffle/'.$this->raffleId.'/comments'), $count);
     }
@@ -128,7 +128,7 @@ class RaffleApiContext implements Context
     /**
      * @Then we should get one of :userNames as a winner
      */
-    public function weShouldGetOneOfAsAWinner(string $userNames)
+    public function weShouldGetOneOfAsAWinner(string $userNames): void
     {
         $users = $this->loadMultipleUsers($userNames);
 
@@ -144,7 +144,7 @@ class RaffleApiContext implements Context
     /**
      * @Then we should get back one of the members that left feedback
      */
-    public function weShouldGetBackOneOfTheMembersThatLeftFeedback()
+    public function weShouldGetBackOneOfTheMembersThatLeftFeedback(): void
     {
         Assert::notNull($this->picked);
     }
@@ -152,7 +152,7 @@ class RaffleApiContext implements Context
     /**
      * @Then :user user should be :count times in the list
      */
-    public function userShouldBeTimesInTheList(JoindInUser $user, int $count)
+    public function userShouldBeTimesInTheList(JoindInUser $user, int $count): void
     {
         $data = $this->apiGetJson('/raffle/'.$this->raffleId.'/comments');
 
@@ -170,7 +170,7 @@ class RaffleApiContext implements Context
     /**
      * @Then we should get :user as a winner
      */
-    public function weShouldGetAsAWinner(JoindInUser $user)
+    public function weShouldGetAsAWinner(JoindInUser $user): void
     {
         Assert::eq($user->getId(), $this->picked['id']);
     }
@@ -179,7 +179,7 @@ class RaffleApiContext implements Context
      * @Then we should have :count eligible comment for next prize
      * @Then we should have :count eligible comments for next prize
      */
-    public function weShouldHaveEligibleCommentForNextPrize(int $count)
+    public function weShouldHaveEligibleCommentForNextPrize(int $count): void
     {
         $data = $this->apiGetJson('/raffle/'.$this->raffleId.'/comments');
 
@@ -189,7 +189,7 @@ class RaffleApiContext implements Context
     /**
      * @Then winners comments should not be eligible for further raffling
      */
-    public function winnersCommentsShouldNotBeEligibleForFurtherRaffling()
+    public function winnersCommentsShouldNotBeEligibleForFurtherRaffling(): void
     {
         $eligibleComments = $this->apiGetJson('/raffle/'.$this->raffleId.'/comments');
 
@@ -210,7 +210,7 @@ class RaffleApiContext implements Context
     /**
      * @Then we cannot continue raffling
      */
-    public function weCannotContinueRaffling()
+    public function weCannotContinueRaffling(): void
     {
         $response = $this->apiPostJson('/raffle/'.$this->raffleId.'/pick');
 
@@ -220,11 +220,12 @@ class RaffleApiContext implements Context
     /**
      * @Then we get an exception for a raffle with no comments
      */
-    public function weGetAnExceptionForARaffleWithNoComments()
+    public function weGetAnExceptionForARaffleWithNoComments(): void
     {
         Assert::eq($this->raffleId, '');
     }
 
+    /** @return mixed */
     private function apiGetJson(string $url)
     {
         $response = $this->getGuzzle()->get($this->testApiUrl.$url);
@@ -232,6 +233,7 @@ class RaffleApiContext implements Context
         return json_decode($response->getBody()->getContents(), true);
     }
 
+    /** @return mixed */
     private function apiPostJson(string $url, array $options = [])
     {
         try {
@@ -248,6 +250,9 @@ class RaffleApiContext implements Context
         return $this->getService(Client::class);
     }
 
+    /**
+     * @return object
+     */
     protected function getService(string $name)
     {
         return $this->kernel->getContainer()->get($name);

--- a/features/bootstrap/RaffleContext.php
+++ b/features/bootstrap/RaffleContext.php
@@ -34,7 +34,7 @@ class RaffleContext implements Context
     /**
      * @When organizer picks to raffle meetups: :eventIdList
      */
-    public function organizerPicksToRaffleMeetups(string $eventIdList)
+    public function organizerPicksToRaffleMeetups(string $eventIdList): void
     {
         $eventIds = explode(',', $eventIdList);
 
@@ -60,7 +60,7 @@ class RaffleContext implements Context
     /**
      * @Then we get an exception for a raffle with no meetups
      */
-    public function weGetAnExceptionForARaffleWithNoMeetups()
+    public function weGetAnExceptionForARaffleWithNoMeetups(): void
     {
         try {
             Raffle::create([]);
@@ -78,7 +78,7 @@ class RaffleContext implements Context
      * @When I pick a winner
      * @When I pick another winner
      */
-    public function wePick()
+    public function wePick(): void
     {
         $raffle = $this->loadRaffle($this->raffleId);
 
@@ -88,7 +88,7 @@ class RaffleContext implements Context
     /**
      * @When I confirm him or her as a winner
      */
-    public function iConfirmHimOrHerAsAWinner()
+    public function iConfirmHimOrHerAsAWinner(): void
     {
         $raffle = $this->loadRaffle($this->raffleId);
 
@@ -104,7 +104,7 @@ class RaffleContext implements Context
     /**
      * @When I mark him or her as a no show
      */
-    public function iMarkHimOrHerAsANoShow()
+    public function iMarkHimOrHerAsANoShow(): void
     {
         $raffle = $this->loadRaffle($this->raffleId);
 
@@ -120,7 +120,7 @@ class RaffleContext implements Context
     /**
      * @When user :user wins
      */
-    public function userWins(JoindInUser $user)
+    public function userWins(JoindInUser $user): void
     {
         $raffle = $this->loadRaffle($this->raffleId);
 
@@ -132,7 +132,7 @@ class RaffleContext implements Context
     /**
      * @When user :user is no show
      */
-    public function userIsNoShow(JoindInUser $user)
+    public function userIsNoShow(JoindInUser $user): void
     {
         $raffle = $this->loadRaffle($this->raffleId);
 
@@ -144,7 +144,7 @@ class RaffleContext implements Context
     /**
      * @Then there should be :count events on the raffle
      */
-    public function thereShouldBeEventsOnTheRaffle(int $count)
+    public function thereShouldBeEventsOnTheRaffle(int $count): void
     {
         $raffle = $this->loadRaffle($this->raffleId);
 
@@ -154,7 +154,7 @@ class RaffleContext implements Context
     /**
      * @Then there should be :count comments on the raffle
      */
-    public function thereShouldBeCommentsOnTheRaffle(int $count)
+    public function thereShouldBeCommentsOnTheRaffle(int $count): void
     {
         $raffle = $this->loadRaffle($this->raffleId);
 
@@ -164,7 +164,7 @@ class RaffleContext implements Context
     /**
      * @Then we should get one of :userNames as a winner
      */
-    public function weShouldGetOneOfAsAWinner(string $userNames)
+    public function weShouldGetOneOfAsAWinner(string $userNames): void
     {
         $users = $this->loadMultipleUsers($userNames);
 
@@ -180,7 +180,7 @@ class RaffleContext implements Context
     /**
      * @Then :user user should be :count times in the list
      */
-    public function userShouldBeTimesInTheList(JoindInUser $user, int $count)
+    public function userShouldBeTimesInTheList(JoindInUser $user, int $count): void
     {
         $raffle = $this->loadRaffle($this->raffleId);
         $found  = 0;
@@ -197,7 +197,7 @@ class RaffleContext implements Context
     /**
      * @Then we should get back one of the members that left feedback
      */
-    public function weShouldGetBackOneOfTheMembersThatLeftFeedback()
+    public function weShouldGetBackOneOfTheMembersThatLeftFeedback(): void
     {
         Assert::notEmpty($this->picked);
     }
@@ -205,7 +205,7 @@ class RaffleContext implements Context
     /**
      * @Then we should get :user as a winner
      */
-    public function weShouldGetAsAWinner(JoindInUser $user)
+    public function weShouldGetAsAWinner(JoindInUser $user): void
     {
         Assert::eq($user, $this->picked);
     }
@@ -214,7 +214,7 @@ class RaffleContext implements Context
      * @Then we should have :count eligible comment for next prize
      * @Then we should have :count eligible comments for next prize
      */
-    public function weShouldHaveEligibleCommentForNextPrize(int $count)
+    public function weShouldHaveEligibleCommentForNextPrize(int $count): void
     {
         $raffle = $this->loadRaffle($this->raffleId);
 
@@ -224,7 +224,7 @@ class RaffleContext implements Context
     /**
      * @Then we cannot continue raffling
      */
-    public function weCannotContinueRaffling()
+    public function weCannotContinueRaffling(): void
     {
         try {
             $raffle = $this->loadRaffle($this->raffleId);
@@ -243,7 +243,7 @@ class RaffleContext implements Context
     /**
      * @Then we get an exception for a raffle with no comments
      */
-    public function weGetAnExceptionForARaffleWithNoComments()
+    public function weGetAnExceptionForARaffleWithNoComments(): void
     {
         Assert::notNull($this->exceptionHappened);
     }
@@ -251,7 +251,7 @@ class RaffleContext implements Context
     /**
      * @Then winners comments should not be eligible for further raffling
      */
-    public function winnersCommentsShouldNotBeEligibleForFurtherRaffling()
+    public function winnersCommentsShouldNotBeEligibleForFurtherRaffling(): void
     {
         if (null !== $this->picked) {
             $winnersComments = $this->picked->getComments();
@@ -262,6 +262,9 @@ class RaffleContext implements Context
         }
     }
 
+    /**
+     * @return object
+     */
     protected function getService(string $name)
     {
         return $this->kernel->getContainer()->get($name);

--- a/features/bootstrap/RaffleFixturesTrait.php
+++ b/features/bootstrap/RaffleFixturesTrait.php
@@ -15,7 +15,7 @@ trait RaffleFixturesTrait
     /**
      * @Given we have a raffle with a single comment coming from :userName
      */
-    public function weHaveARaffleWithASingleCommentComingFrom(string $userName)
+    public function weHaveARaffleWithASingleCommentComingFrom(string $userName): void
     {
         $event   = new JoindInEvent(1, 'Meetup #1', new DateTime('today'));
         $talk    = new JoindInTalk(1, 'Talk on meetup #1', $event);

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -53,7 +53,7 @@ class HomepageController
         return new Response('OK');
     }
 
-    public function fetchJoindInData()
+    public function fetchJoindInData(): \Symfony\Component\HttpFoundation\Response
     {
         try {
             $this->joindInEventRetrieval->fetch();

--- a/src/DataFixtures/ORM/EmptyFixtures.php
+++ b/src/DataFixtures/ORM/EmptyFixtures.php
@@ -13,7 +13,7 @@ class EmptyFixtures extends AbstractFixture implements OrderedFixtureInterface
     /**
      * {@inheritdoc}
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         //$obj = new \stdClass();
         //$manager->persist($obj);
@@ -25,7 +25,7 @@ class EmptyFixtures extends AbstractFixture implements OrderedFixtureInterface
     /**
      * {@inheritdoc}
      */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 10;
     }

--- a/src/DataFixtures/ORM/JoindInCommentsFixtures.php
+++ b/src/DataFixtures/ORM/JoindInCommentsFixtures.php
@@ -11,7 +11,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 
 class JoindInCommentsFixtures extends AbstractFixture implements OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $fullStacking101Talk = $this->getReference('october-talk-22817');
 
@@ -59,7 +59,7 @@ class JoindInCommentsFixtures extends AbstractFixture implements OrderedFixtureI
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 40;
     }

--- a/src/DataFixtures/ORM/JoindInEventsFixtures.php
+++ b/src/DataFixtures/ORM/JoindInEventsFixtures.php
@@ -12,7 +12,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 
 class JoindInEventsFixtures extends AbstractFixture implements OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $list = [
             'october'   => new JoindInEvent(6674, 'ZgPHP 2017/10', new DateTime('2017-10-19')),
@@ -36,7 +36,7 @@ class JoindInEventsFixtures extends AbstractFixture implements OrderedFixtureInt
     /**
      * {@inheritdoc}
      */
-    public function getOrder()
+    public function getOrder(): int
     {
         return 10;
     }

--- a/src/DataFixtures/ORM/JoindInTalksFixtures.php
+++ b/src/DataFixtures/ORM/JoindInTalksFixtures.php
@@ -11,7 +11,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 
 class JoindInTalksFixtures extends AbstractFixture implements OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $octoberMeetup = $this->getReference('event-october');
 
@@ -29,7 +29,7 @@ class JoindInTalksFixtures extends AbstractFixture implements OrderedFixtureInte
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 20;
     }

--- a/src/DataFixtures/ORM/JoindInUsersFixtures.php
+++ b/src/DataFixtures/ORM/JoindInUsersFixtures.php
@@ -11,7 +11,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 
 class JoindInUsersFixtures extends AbstractFixture implements OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $users = [
             'user1'      => new JoindInUser(45128, 'username1', 'User Named One', false),
@@ -28,7 +28,7 @@ class JoindInUsersFixtures extends AbstractFixture implements OrderedFixtureInte
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 30;
     }

--- a/src/DataFixtures/ORM/UserFixtures.php
+++ b/src/DataFixtures/ORM/UserFixtures.php
@@ -11,7 +11,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 
 class UserFixtures extends AbstractFixture implements OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $admin = new User();
         $admin->setUsername('admin');
@@ -26,7 +26,7 @@ class UserFixtures extends AbstractFixture implements OrderedFixtureInterface
         $manager->flush();
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 10;
     }

--- a/src/Entity/JoindInComment.php
+++ b/src/Entity/JoindInComment.php
@@ -59,22 +59,22 @@ class JoindInComment implements \JsonSerializable
         $this->talk    = $talk;
     }
 
-    public function setComment(string $comment)
+    public function setComment(string $comment): void
     {
         $this->comment = $comment;
     }
 
-    public function setRating(int $rating)
+    public function setRating(int $rating): void
     {
         $this->rating = $rating;
     }
 
-    public function setUser(JoindInUser $user)
+    public function setUser(JoindInUser $user): void
     {
         $this->user = $user;
     }
 
-    public function setTalk(JoindInTalk $talk)
+    public function setTalk(JoindInTalk $talk): void
     {
         $this->talk = $talk;
     }

--- a/src/Entity/JoindInEvent.php
+++ b/src/Entity/JoindInEvent.php
@@ -53,12 +53,12 @@ class JoindInEvent implements \JsonSerializable
         $this->talks = new ArrayCollection();
     }
 
-    public function setName(string $name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    public function setDate(DateTime $date)
+    public function setDate(DateTime $date): void
     {
         $this->date = $date;
     }
@@ -83,7 +83,7 @@ class JoindInEvent implements \JsonSerializable
         return $this->talks;
     }
 
-    public function addTalk(JoindInTalk $talk)
+    public function addTalk(JoindInTalk $talk): void
     {
         $this->talks->add($talk);
     }

--- a/src/Entity/JoindInTalk.php
+++ b/src/Entity/JoindInTalk.php
@@ -62,12 +62,12 @@ class JoindInTalk implements \JsonSerializable
         $this->comments = new ArrayCollection();
     }
 
-    public function setTitle(string $title)
+    public function setTitle(string $title): void
     {
         $this->title = $title;
     }
 
-    public function setEvent(JoindInEvent $event)
+    public function setEvent(JoindInEvent $event): void
     {
         $this->event = $event;
     }
@@ -97,7 +97,7 @@ class JoindInTalk implements \JsonSerializable
         return $this->comments;
     }
 
-    public function addComment(JoindInComment $comment)
+    public function addComment(JoindInComment $comment): void
     {
         $this->comments->add($comment);
     }

--- a/src/Entity/JoindInUser.php
+++ b/src/Entity/JoindInUser.php
@@ -68,7 +68,7 @@ class JoindInUser implements \JsonSerializable
         return $this->username;
     }
 
-    public function setUsername(string $username)
+    public function setUsername(string $username): void
     {
         $this->username = $username;
     }
@@ -78,7 +78,7 @@ class JoindInUser implements \JsonSerializable
         return $this->displayName;
     }
 
-    public function setDisplayName(string $displayName)
+    public function setDisplayName(string $displayName): void
     {
         $this->displayName = $displayName;
     }
@@ -103,7 +103,7 @@ class JoindInUser implements \JsonSerializable
     /**
      * @param JoindInComment $comment
      */
-    public function addComment(JoindInComment $comment)
+    public function addComment(JoindInComment $comment): void
     {
         $this->comments->add($comment);
     }
@@ -116,7 +116,7 @@ class JoindInUser implements \JsonSerializable
         return $this->organizer;
     }
 
-    public function promoteToOrganizer()
+    public function promoteToOrganizer(): void
     {
         $this->organizer = true;
     }

--- a/src/Entity/Raffle.php
+++ b/src/Entity/Raffle.php
@@ -147,12 +147,12 @@ class Raffle implements \JsonSerializable
         return $comments[0]->getUser();
     }
 
-    public function userWon(JoindInUser $user)
+    public function userWon(JoindInUser $user): void
     {
         $this->winners->add($user);
     }
 
-    public function userIsNoShow(JoindInUser $user)
+    public function userIsNoShow(JoindInUser $user): void
     {
         $this->noShows->add($user);
     }
@@ -208,7 +208,7 @@ class Raffle implements \JsonSerializable
         return true;
     }
 
-    public function getCommentsNotEligibleForRaffling()
+    public function getCommentsNotEligibleForRaffling(): \Doctrine\Common\Collections\ArrayCollection
     {
         $comments = new ArrayCollection();
 
@@ -227,12 +227,12 @@ class Raffle implements \JsonSerializable
         return $comments;
     }
 
-    public function getWinners()
+    public function getWinners(): \Doctrine\Common\Collections\Collection
     {
         return $this->winners;
     }
 
-    public function getNoShows()
+    public function getNoShows(): \Doctrine\Common\Collections\Collection
     {
         return $this->noShows;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -36,7 +36,7 @@ class User extends BaseUser
         return $this->isSuperAdmin();
     }
 
-    public function setAdministrator($boolean)
+    public function setAdministrator($boolean): void
     {
         $this->setSuperAdmin($boolean);
         $this->administrator = $boolean;

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -36,7 +36,7 @@ class Kernel extends BaseKernel
         }
     }
 
-    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $container->setParameter('container.autowiring.strict_mode', true);
         $confDir = dirname(__DIR__).'/config';
@@ -48,7 +48,7 @@ class Kernel extends BaseKernel
         $loader->load($confDir.'/services_'.$this->environment.self::CONFIG_EXTS, 'glob');
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes)
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
     {
         $confDir = dirname(__DIR__).'/config';
         if (is_dir($confDir.'/routes/')) {

--- a/src/Migrations/Version20171102223552.php
+++ b/src/Migrations/Version20171102223552.php
@@ -15,7 +15,7 @@ class Version20171102223552 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
@@ -27,7 +27,7 @@ class Version20171102223552 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');

--- a/src/Migrations/Version20171102224527.php
+++ b/src/Migrations/Version20171102224527.php
@@ -15,7 +15,7 @@ class Version20171102224527 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
@@ -27,7 +27,7 @@ class Version20171102224527 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');

--- a/src/Migrations/Version20171103224656.php
+++ b/src/Migrations/Version20171103224656.php
@@ -15,7 +15,7 @@ class Version20171103224656 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
@@ -28,7 +28,7 @@ class Version20171103224656 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');

--- a/src/Migrations/Version20171104122657.php
+++ b/src/Migrations/Version20171104122657.php
@@ -15,7 +15,7 @@ class Version20171104122657 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
@@ -26,7 +26,7 @@ class Version20171104122657 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');

--- a/src/Migrations/Version20171104123424.php
+++ b/src/Migrations/Version20171104123424.php
@@ -15,7 +15,7 @@ class Version20171104123424 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
@@ -30,7 +30,7 @@ class Version20171104123424 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');

--- a/src/Migrations/Version20171104183806.php
+++ b/src/Migrations/Version20171104183806.php
@@ -15,7 +15,7 @@ class Version20171104183806 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
@@ -45,7 +45,7 @@ class Version20171104183806 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');

--- a/src/Migrations/Version20171108224445.php
+++ b/src/Migrations/Version20171108224445.php
@@ -13,7 +13,7 @@ class Version20171108224445 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration is modified to preserve the already present data in table, rename the column, and set
         // it to accept null values
@@ -26,7 +26,7 @@ class Version20171108224445 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration is modified to preserve the already present data in table, revert the the column
         // name and null value acceptance, and to not try to recreate an existing 'public' schema

--- a/src/Migrations/Version20171111002932.php
+++ b/src/Migrations/Version20171111002932.php
@@ -13,7 +13,7 @@ class Version20171111002932 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration is modified to preserve the 'enddate' column, which still holds orphan data
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
@@ -27,7 +27,7 @@ class Version20171111002932 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');

--- a/src/Migrations/Version20171111192937.php
+++ b/src/Migrations/Version20171111192937.php
@@ -13,7 +13,7 @@ class Version20171111192937 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
@@ -24,7 +24,7 @@ class Version20171111192937 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration is modified as to not try to recreate an existing 'public' schema
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');

--- a/src/Migrations/Version20171113151536.php
+++ b/src/Migrations/Version20171113151536.php
@@ -13,7 +13,7 @@ class Version20171113151536 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
@@ -24,7 +24,7 @@ class Version20171113151536 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');

--- a/src/Migrations/Version20171114112949.php
+++ b/src/Migrations/Version20171114112949.php
@@ -14,7 +14,7 @@ class Version20171114112949 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration promotes two records as ZgPhp Meetup organizers
         $this->addSql('UPDATE joindinUsers SET organizer = TRUE WHERE id IN (18486, 31686)');
@@ -23,7 +23,7 @@ class Version20171114112949 extends AbstractMigration
     /**
      * @param Schema $schema
      */
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration demotes two records representing ZgPhp Meetup organizers
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(),

--- a/src/Migrations/Version20171130130243.php
+++ b/src/Migrations/Version20171130130243.php
@@ -12,7 +12,7 @@ use Doctrine\DBAL\Schema\Schema;
  */
 class Version20171130130243 extends AbstractMigration
 {
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
@@ -25,7 +25,7 @@ class Version20171130130243 extends AbstractMigration
         $this->addSql('COMMENT ON COLUMN fos_user.roles IS \'(DC2Type:array)\'');
     }
 
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');

--- a/src/Migrations/Version20180126123008.php
+++ b/src/Migrations/Version20180126123008.php
@@ -12,13 +12,13 @@ use Doctrine\DBAL\Schema\Schema;
  */
 class Version20180126123008 extends AbstractMigration
 {
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration promotes four records as ZgPhp Meetup organizers
         $this->addSql('UPDATE joindinUsers SET organizer = TRUE WHERE id IN (27939, 31316, 47268, 26764)');
     }
 
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration demotes four records representing ZgPhp Meetup organizers
         $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(),

--- a/src/Repository/JoindInUserRepository.php
+++ b/src/Repository/JoindInUserRepository.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\JoindInUser;
 use Doctrine\ORM\EntityRepository;
 
 class JoindInUserRepository extends EntityRepository
 {
-    public function findOneByUsername(string $username)
+    public function findOneByUsername(string $username): ?JoindInUser
     {
         return parent::findOneByUsername($username);
     }

--- a/src/Service/JoindInClient.php
+++ b/src/Service/JoindInClient.php
@@ -25,6 +25,7 @@ class JoindInClient
     /** @var CommentDataFactory */
     private $commentDataFactory;
 
+    /** @var string */
     private $baseUrl = 'https://api.joind.in/v2.1';
 
     public function __construct(

--- a/src/UuidType.php
+++ b/src/UuidType.php
@@ -41,7 +41,7 @@ class UuidType extends Type
      * @param array                                     $fieldDeclaration
      * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
      */
-    public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return $platform->getGuidTypeDeclarationSQL($fieldDeclaration);
     }
@@ -63,7 +63,7 @@ class UuidType extends Type
      * @param UuidInterface|null                        $value
      * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
      */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         if (empty($value)) {
             return null;
@@ -81,7 +81,7 @@ class UuidType extends Type
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }
@@ -93,7 +93,7 @@ class UuidType extends Type
      *
      * @return bool
      */
-    public function requiresSqlCommentHint(AbstractPlatform $platform)
+    public function requiresSqlCommentHint(AbstractPlatform $platform): bool
     {
         return true;
     }

--- a/tests/Entity/JoindInCommentTest.php
+++ b/tests/Entity/JoindInCommentTest.php
@@ -25,53 +25,53 @@ class JoindInCommentTest extends TestCase
     /** @var JoindInComment */
     private $joindInComment;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->user           = Mockery::mock(JoindInUser::class);
         $this->talk           = Mockery::mock(JoindInTalk::class);
         $this->joindInComment = new JoindInComment(1, 'comment', 5, $this->user, $this->talk);
     }
 
-    public function testGetId()
+    public function testGetId(): void
     {
         self::assertEquals(1, $this->joindInComment->getId());
     }
 
-    public function testGetComment()
+    public function testGetComment(): void
     {
         self::assertEquals('comment', $this->joindInComment->getComment());
     }
 
-    public function testGetRating()
+    public function testGetRating(): void
     {
         self::assertEquals(5, $this->joindInComment->getRating());
     }
 
-    public function testGetUser()
+    public function testGetUser(): void
     {
         self::assertEquals($this->user, $this->joindInComment->getUser());
     }
 
-    public function testGetTalk()
+    public function testGetTalk(): void
     {
         self::assertEquals($this->talk, $this->joindInComment->getTalk());
     }
 
-    public function testSetComment()
+    public function testSetComment(): void
     {
         self::assertEquals('comment', $this->joindInComment->getComment());
         $this->joindInComment->setComment('changed comment');
         self::assertEquals('changed comment', $this->joindInComment->getComment());
     }
 
-    public function testSetRating()
+    public function testSetRating(): void
     {
         self::assertEquals(5, $this->joindInComment->getRating());
         $this->joindInComment->setRating(4);
         self::assertEquals(4, $this->joindInComment->getRating());
     }
 
-    public function testSetUser()
+    public function testSetUser(): void
     {
         self::assertEquals($this->user, $this->joindInComment->getUser());
 
@@ -82,7 +82,7 @@ class JoindInCommentTest extends TestCase
         self::assertEquals($newUser, $this->joindInComment->getUser());
     }
 
-    public function testSetTalk()
+    public function testSetTalk(): void
     {
         self::assertEquals($this->talk, $this->joindInComment->getTalk());
 
@@ -93,7 +93,7 @@ class JoindInCommentTest extends TestCase
         self::assertEquals($newTalk, $this->joindInComment->getTalk());
     }
 
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         // Arrange.
         $this->user->shouldReceive('jsonSerialize')->once()->andReturn(['user serialized data']);

--- a/tests/Entity/JoindInEventTest.php
+++ b/tests/Entity/JoindInEventTest.php
@@ -25,7 +25,7 @@ class JoindInEventTest extends TestCase
     /** @var JoindInEvent */
     private $joindInEvent;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->id           = 1;
         $this->name         = 'name';
@@ -33,42 +33,42 @@ class JoindInEventTest extends TestCase
         $this->joindInEvent = new JoindInEvent($this->id, $this->name, $this->date);
     }
 
-    public function testSetName()
+    public function testSetName(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testSetDate()
+    public function testSetDate(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testGetId()
+    public function testGetId(): void
     {
         self::assertEquals($this->id, $this->joindInEvent->getId());
     }
 
-    public function testGetName()
+    public function testGetName(): void
     {
         self::assertEquals($this->name, $this->joindInEvent->getName());
     }
 
-    public function testGetDate()
+    public function testGetDate(): void
     {
         self::assertEquals($this->date, $this->joindInEvent->getDate());
     }
 
-    public function testGetTalks()
+    public function testGetTalks(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testAddTalk()
+    public function testAddTalk(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $this->markTestSkipped('Skipping');
     }

--- a/tests/Entity/JoindInTalkTest.php
+++ b/tests/Entity/JoindInTalkTest.php
@@ -25,7 +25,7 @@ class JoindInTalkTest extends TestCase
     /** @var JoindInTalk */
     private $joindInTalk;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->id          = 1;
         $this->title       = 'title';
@@ -33,47 +33,47 @@ class JoindInTalkTest extends TestCase
         $this->joindInTalk = new JoindInTalk($this->id, $this->title, $this->event);
     }
 
-    public function testSetTitle()
+    public function testSetTitle(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testSetEvent()
+    public function testSetEvent(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testGetId()
+    public function testGetId(): void
     {
         self::assertEquals($this->id, $this->joindInTalk->getId());
     }
 
-    public function testGetTitle()
+    public function testGetTitle(): void
     {
         self::assertEquals($this->title, $this->joindInTalk->getTitle());
     }
 
-    public function testGetEvent()
+    public function testGetEvent(): void
     {
         self::assertEquals($this->event, $this->joindInTalk->getEvent());
     }
 
-    public function testGetCreatedAt()
+    public function testGetCreatedAt(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testGetComments()
+    public function testGetComments(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testAddComment()
+    public function testAddComment(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $this->markTestSkipped('Skipping');
     }

--- a/tests/Entity/JoindInUserTest.php
+++ b/tests/Entity/JoindInUserTest.php
@@ -24,7 +24,7 @@ class JoindInUserTest extends TestCase
     /** @var bool */
     private $organizer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->id          = 1;
         $this->username    = 'username';
@@ -33,53 +33,53 @@ class JoindInUserTest extends TestCase
         $this->joindInUser = new JoindInUser($this->id, $this->username, $this->displayName, $this->organizer);
     }
 
-    public function testSetUsername()
+    public function testSetUsername(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testSetDisplayName()
+    public function testSetDisplayName(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testPromoteToOrganizer()
+    public function testPromoteToOrganizer(): void
     {
         $this->joindInUser->promoteToOrganizer();
         self::assertEquals(true, $this->joindInUser->isOrganizer());
     }
 
-    public function testIsOrganizer()
+    public function testIsOrganizer(): void
     {
         self::assertEquals($this->organizer, $this->joindInUser->isOrganizer());
     }
 
-    public function testGetId()
+    public function testGetId(): void
     {
         self::assertEquals($this->id, $this->joindInUser->getId());
     }
 
-    public function testGetUsername()
+    public function testGetUsername(): void
     {
         self::assertEquals($this->username, $this->joindInUser->getUsername());
     }
 
-    public function testGetDisplayName()
+    public function testGetDisplayName(): void
     {
         self::assertEquals($this->displayName, $this->joindInUser->getDisplayName());
     }
 
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testGetComments()
+    public function testGetComments(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testAddComment()
+    public function testAddComment(): void
     {
         $this->markTestSkipped('Skipping');
     }

--- a/tests/Entity/RaffleTest.php
+++ b/tests/Entity/RaffleTest.php
@@ -21,7 +21,7 @@ class RaffleTest extends TestCase
     /**
      * @expectedException \App\Exception\NoEventsToRaffleException
      */
-    public function testCannotCreateEmptyRaffle()
+    public function testCannotCreateEmptyRaffle(): void
     {
         Raffle::create([]);
     }
@@ -29,7 +29,7 @@ class RaffleTest extends TestCase
     /**
      * @expectedException \App\Exception\NoCommentsToRaffleException
      */
-    public function testCannotStartRaffleWithNoCommentsInEvents()
+    public function testCannotStartRaffleWithNoCommentsInEvents(): void
     {
         // Arrange.
         $talk1 = Mockery::mock(JoindInTalk::class);
@@ -48,7 +48,7 @@ class RaffleTest extends TestCase
     /**
      * @expectedException \App\Exception\NoCommentsToRaffleException
      */
-    public function testCannotStartRaffleWhenThereAreNoTalksOnSelectedEvents()
+    public function testCannotStartRaffleWhenThereAreNoTalksOnSelectedEvents(): void
     {
         // Arrange.
         $event1 = new JoindInEvent(1, 'Meetup 1', new \DateTime());
@@ -62,7 +62,7 @@ class RaffleTest extends TestCase
         new Raffle('id', $events);
     }
 
-    public function testRaffleWillBeCreated()
+    public function testRaffleWillBeCreated(): void
     {
         // Arrange.
 
@@ -83,7 +83,7 @@ class RaffleTest extends TestCase
         $this->assertInstanceOf(Raffle::class, $raffle);
     }
 
-    public function testRaffleWillBeCreated2()
+    public function testRaffleWillBeCreated2(): void
     {
         // Arrange.
 

--- a/tests/Exception/NoCommentsToRaffleExceptionTest.php
+++ b/tests/Exception/NoCommentsToRaffleExceptionTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
  */
 class NoCommentsToRaffleExceptionTest extends TestCase
 {
-    public function testForRaffle()
+    public function testForRaffle(): void
     {
         $this->assertInstanceOf(NoCommentsToRaffleException::class, NoCommentsToRaffleException::forRaffle('123'));
     }

--- a/tests/JoindIn/CommentDataFactoryTest.php
+++ b/tests/JoindIn/CommentDataFactoryTest.php
@@ -19,12 +19,12 @@ class CommentDataFactoryTest extends TestCase
     /** @var CommentDataFactory */
     private $commentDataFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->commentDataFactory = new CommentDataFactory();
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         // Arrange.
         $input = [

--- a/tests/JoindIn/CommentDataTest.php
+++ b/tests/JoindIn/CommentDataTest.php
@@ -24,49 +24,49 @@ class CommentDataTest extends TestCase
     /** @var CommentData */
     private $commentData;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->userData    = new UserData(100001, 'username', 'Vanja Horvat');
         $this->talk        = new JoindInTalk(30000, 'Developing xyz', Mockery::mock(JoindInEvent::class));
         $this->commentData = new CommentData(1, 'comment', 5, $this->userData, $this->talk);
     }
 
-    public function testGetId()
+    public function testGetId(): void
     {
         self::assertEquals(1, $this->commentData->getId());
     }
 
-    public function testGetComment()
+    public function testGetComment(): void
     {
         self::assertEquals('comment', $this->commentData->getComment());
     }
 
-    public function testGetRating()
+    public function testGetRating(): void
     {
         self::assertEquals(5, $this->commentData->getRating());
     }
 
-    public function testGetUserData()
+    public function testGetUserData(): void
     {
         self::assertEquals($this->userData, $this->commentData->getUserData());
     }
 
-    public function testGetUserId()
+    public function testGetUserId(): void
     {
         self::assertEquals(100001, $this->commentData->getUserId());
     }
 
-    public function testGetUserName()
+    public function testGetUserName(): void
     {
         self::assertEquals('username', $this->commentData->getUserName());
     }
 
-    public function testGetUserDisplayName()
+    public function testGetUserDisplayName(): void
     {
         self::assertEquals('Vanja Horvat', $this->commentData->getUserDisplayName());
     }
 
-    public function testGetTalk()
+    public function testGetTalk(): void
     {
         self::assertEquals($this->talk, $this->commentData->getTalk());
     }

--- a/tests/JoindIn/EventDataFactoryTest.php
+++ b/tests/JoindIn/EventDataFactoryTest.php
@@ -16,12 +16,12 @@ class EventDataFactoryTest extends TestCase
     /** @var EventDataFactory */
     private $eventDataFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->eventDataFactory = new EventDataFactory();
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $this->markTestSkipped('Skipping');
     }

--- a/tests/JoindIn/EventDataTest.php
+++ b/tests/JoindIn/EventDataTest.php
@@ -25,7 +25,7 @@ class EventDataTest extends TestCase
     /** @var EventData */
     private $eventData;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->id        = 1;
         $this->name      = 'name';
@@ -33,17 +33,17 @@ class EventDataTest extends TestCase
         $this->eventData = new EventData($this->id, $this->name, $this->date);
     }
 
-    public function testGetId()
+    public function testGetId(): void
     {
         self::assertEquals($this->id, $this->eventData->getId());
     }
 
-    public function testGetName()
+    public function testGetName(): void
     {
         self::assertEquals($this->name, $this->eventData->getName());
     }
 
-    public function testGetDate()
+    public function testGetDate(): void
     {
         self::assertEquals($this->date, $this->eventData->getDate());
     }

--- a/tests/JoindIn/TalkDataFactoryTest.php
+++ b/tests/JoindIn/TalkDataFactoryTest.php
@@ -16,12 +16,12 @@ class TalkDataFactoryTest extends TestCase
     /** @var TalkDataFactory */
     private $talkDataFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->talkDataFactory = new TalkDataFactory();
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $this->markTestSkipped('Skipping');
     }

--- a/tests/JoindIn/TalkDataTest.php
+++ b/tests/JoindIn/TalkDataTest.php
@@ -25,7 +25,7 @@ class TalkDataTest extends TestCase
     /** @var TalkData */
     private $talkData;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->id       = 1;
         $this->title    = 'title';
@@ -33,17 +33,17 @@ class TalkDataTest extends TestCase
         $this->talkData = new TalkData($this->id, $this->title, $this->event);
     }
 
-    public function testGetId()
+    public function testGetId(): void
     {
         self::assertEquals($this->id, $this->talkData->getId());
     }
 
-    public function testGetTitle()
+    public function testGetTitle(): void
     {
         self::assertEquals($this->title, $this->talkData->getTitle());
     }
 
-    public function testGetEvent()
+    public function testGetEvent(): void
     {
         self::assertEquals($this->event, $this->talkData->getEvent());
     }

--- a/tests/JoindIn/UserDataTest.php
+++ b/tests/JoindIn/UserDataTest.php
@@ -22,7 +22,7 @@ class UserDataTest extends TestCase
     /** @var UserData */
     private $userData;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->id          = 1;
         $this->username    = 'username';
@@ -30,17 +30,17 @@ class UserDataTest extends TestCase
         $this->userData    = new UserData($this->id, $this->username, $this->displayName);
     }
 
-    public function testGetId()
+    public function testGetId(): void
     {
         self::assertEquals($this->id, $this->userData->getId());
     }
 
-    public function testGetUsername()
+    public function testGetUsername(): void
     {
         self::assertEquals($this->username, $this->userData->getUsername());
     }
 
-    public function testGetDisplayName()
+    public function testGetDisplayName(): void
     {
         self::assertEquals($this->displayName, $this->userData->getDisplayName());
     }

--- a/tests/NoTest.php
+++ b/tests/NoTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class NoTest extends TestCase
 {
-    public function testNothing()
+    public function testNothing(): void
     {
         self::assertEquals(1, '1');
     }

--- a/tests/Service/JoindInClientTest.php
+++ b/tests/Service/JoindInClientTest.php
@@ -30,7 +30,7 @@ class JoindInClientTest extends TestCase
     /** @var JoindInClient */
     private $joindInClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client             = Mockery::mock(Client::class);
         $this->eventDataFactory   = Mockery::mock(EventDataFactory::class);
@@ -39,17 +39,17 @@ class JoindInClientTest extends TestCase
         $this->joindInClient      = new JoindInClient($this->client, $this->eventDataFactory, $this->talkDataFactory, $this->commentDataFactory);
     }
 
-    public function testFetchZgPhpEvents()
+    public function testFetchZgPhpEvents(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testFetchTalksForEvent()
+    public function testFetchTalksForEvent(): void
     {
         $this->markTestSkipped('Skipping');
     }
 
-    public function testFetchCommentsForTalk()
+    public function testFetchCommentsForTalk(): void
     {
         $this->markTestSkipped('Skipping');
     }

--- a/tests/Service/JoindInCommentRetrievalTest.php
+++ b/tests/Service/JoindInCommentRetrievalTest.php
@@ -30,7 +30,7 @@ class JoindInCommentRetrievalTest extends TestCase
     /** @var JoindInCommentRetrieval */
     private $joindInCommentRetrieval;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->joindInClient           = Mockery::mock(JoindInClient::class);
         $this->entityManager           = Mockery::mock(EntityManagerInterface::class);
@@ -44,7 +44,7 @@ class JoindInCommentRetrievalTest extends TestCase
         );
     }
 
-    public function testFetch()
+    public function testFetch(): void
     {
         $this->markTestSkipped('Skipping');
     }

--- a/tests/Service/JoindInEventRetrievalTest.php
+++ b/tests/Service/JoindInEventRetrievalTest.php
@@ -27,7 +27,7 @@ class JoindInEventRetrievalTest extends TestCase
     /** @var JoindInEventRetrieval */
     private $joindInEventRetrieval;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->joindInClient         = Mockery::mock(JoindInClient::class);
         $this->entityManager         = Mockery::mock(EntityManagerInterface::class);
@@ -35,7 +35,7 @@ class JoindInEventRetrievalTest extends TestCase
         $this->joindInEventRetrieval = new JoindInEventRetrieval($this->joindInClient, $this->entityManager, $this->eventRepository);
     }
 
-    public function testFetch()
+    public function testFetch(): void
     {
         $this->markTestSkipped('Skipping');
     }

--- a/tests/Service/JoindInTalkRetrievalTest.php
+++ b/tests/Service/JoindInTalkRetrievalTest.php
@@ -27,7 +27,7 @@ class JoindInTalkRetrievalTest extends TestCase
     /** @var JoindInTalkRetrieval */
     private $joindInTalkRetrieval;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->joindInClient        = Mockery::mock(JoindInClient::class);
         $this->entityManager        = Mockery::mock(EntityManagerInterface::class);
@@ -35,7 +35,7 @@ class JoindInTalkRetrievalTest extends TestCase
         $this->joindInTalkRetrieval = new JoindInTalkRetrieval($this->joindInClient, $this->entityManager, $this->talkRepository);
     }
 
-    public function testFetch()
+    public function testFetch(): void
     {
         $this->markTestSkipped('Skipping');
     }


### PR DESCRIPTION
Lets make our code more resiliant by using return types everywhere. This commit is one of many to prepare existing code for running PHPStan with strict extension turned on.

